### PR TITLE
코드베이스 생성 스크립트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@types/supertest": "^6.0.2",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "commander": "^14.0.0",
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
@@ -56,6 +57,9 @@
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
         "testcontainers": "^10.8.2",
+        "to-camel-case": "^1.0.0",
+        "to-pascal-case": "^1.0.0",
+        "to-snake-case": "^1.0.0",
         "ts-jest": "^29.2.5",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
@@ -2413,6 +2417,16 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@nestjs/cli/node_modules/eslint-scope": {
@@ -6304,13 +6318,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">=20"
       }
     },
     "node_modules/comment-json": {
@@ -12875,6 +12889,33 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/to-camel-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
+      "integrity": "sha512-nD8pQi5H34kyu1QDMFjzEIYqk0xa9Alt6ZfrdEMuHCFOfTLhDG5pgTu/aAM9Wt9lXILwlXmWP43b8sav0GNE8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "node_modules/to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-pascal-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-pascal-case/-/to-pascal-case-1.0.0.tgz",
+      "integrity": "sha512-QGMWHqM6xPrcQW57S23c5/3BbYb0Tbe9p+ur98ckRnGDwD4wbbtDiYI38CfmMKNB5Iv0REjs5SNDntTwvDxzZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12885,6 +12926,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "node_modules/to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-no-case": "^1.0.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "gen:usecase": "ts-node scripts/generate-usecase-preset.script.ts",
+    "gen:domain": "ts-node scripts/generate-domain.script.ts"
   },
   "dependencies": {
     "@mikro-orm/cli": "^6.4.16",
@@ -62,6 +64,7 @@
     "@types/supertest": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "commander": "^14.0.0",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
@@ -72,6 +75,9 @@
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "testcontainers": "^10.8.2",
+    "to-camel-case": "^1.0.0",
+    "to-pascal-case": "^1.0.0",
+    "to-snake-case": "^1.0.0",
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",

--- a/scripts/generate-usecase-preset.script.ts
+++ b/scripts/generate-usecase-preset.script.ts
@@ -1,0 +1,244 @@
+import { exec } from 'child_process';
+import { Command } from 'commander';
+import { writeFileSync } from 'fs';
+import * as path from 'path';
+import camelCase from 'to-camel-case';
+import pascalCase from 'to-pascal-case';
+import snakeCase from 'to-snake-case';
+
+const program = new Command();
+
+const PRESETS = {
+  MODULE_PRESET: `import { Module } from '@nestjs/common';
+
+import { UseCaseNameController } from '@module/module-name/use-cases/use-case-name/use-case-name.controller';
+import { UseCaseNameHandler } from '@module/module-name/use-cases/use-case-name/use-case-name.handler';
+
+@Module({
+  controllers: [UseCaseNameController],
+  providers: [UseCaseNameHandler],
+})
+export class UseCaseNameModule {}
+`,
+
+  CONTROLLER_PRESET: `import { Controller, HttpStatus } from '@nestjs/common';
+import { OperationNameBus } from '@nestjs/cqrs';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { UseCaseNameOperationName } from '@module/module-name/use-cases/use-case-name/use-case-name.operation-name';
+
+import { RequestValidationError } from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+
+@ApiTags('module-name')
+@Controller()
+export class UseCaseNameController {
+  constructor(
+    private readonly operationNameBus: OperationNameBus,
+  ) {}
+
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+  })
+  @ApiOperation({ summary: '' })
+  async useCaseName() {
+    try {
+      const operationName = new UseCaseNameOperationName({});
+    
+      const result = await this.operationNameBus.execute<UseCaseNameOperationName, unknown>(operationName);
+    } catch (error) {
+      throw error 
+    }
+  }
+}
+`,
+
+  HANDLER_PRESET: `import { OperationNameHandler, IOperationNameHandler } from '@nestjs/cqrs';
+
+import { UseCaseNameOperationName } from '@module/module-name/use-cases/use-case-name/use-case-name.operation-name';
+
+@OperationNameHandler(UseCaseNameOperationName)
+export class UseCaseNameHandler implements IOperationNameHandler<UseCaseNameOperationName, unknown> {
+  constructor() {}
+
+  async execute(operationName: UseCaseNameOperationName): Promise<unknown> {
+    throw new Error('Method not implemented.');
+  }
+}
+`,
+
+  HANDLER_SPEC_PRESET: `import { Test, TestingModule } from '@nestjs/testing';
+
+import { UseCaseNameOperationNameFactory } from '@module/module-name/use-cases/use-case-name/__spec__/use-case-name-operation-name.factory';
+import { UseCaseNameOperationName } from '@module/module-name/use-cases/use-case-name/use-case-name.operation-name';
+import { UseCaseNameHandler } from '@module/module-name/use-cases/use-case-name/use-case-name.handler';
+
+describe(UseCaseNameHandler.name, () => {
+  let handler: UseCaseNameHandler;
+
+  let operationName: UseCaseNameOperationName;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UseCaseNameHandler],
+    }).compile();
+
+    handler = module.get<UseCaseNameHandler>(UseCaseNameHandler);
+  });
+
+  beforeEach(() => {
+    operationName = UseCaseNameOperationNameFactory.build();
+  });
+});
+`,
+
+  OPERATION_PRESET: `import { IOperationName } from '@nestjs/cqrs';
+
+export interface IUseCaseNameOperationNameProps {}
+
+export class UseCaseNameOperationName implements IOperationName {
+  constructor(props: IUseCaseNameOperationNameProps) {}
+}
+`,
+
+  FACTORY_OPERATION_PRESET: `import { Factory } from 'rosie';
+
+import { UseCaseNameOperationName } from '@module/module-name/use-cases/use-case-name/use-case-name.operation-name';
+
+export const UseCaseNameOperationNameFactory = Factory.define<UseCaseNameOperationName>(
+  UseCaseNameOperationName.name,
+  UseCaseNameOperationName,
+).attrs({});
+`,
+
+  DTO_PRESET: `export class UseCaseNameDto {}
+`,
+};
+
+// 명령어 실행 함수
+const runCommand = (command: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error executing command: ${command}`);
+        console.error(stderr);
+        reject(error);
+        return;
+      }
+      console.log(stdout);
+      resolve();
+    });
+  });
+};
+
+// CLI 명령어 정의
+program
+  .name('generate-usecase')
+  .description('Generate a new use case with module, controller, and handler.')
+  .version('1.0.0')
+  .argument('<module>', 'Name of the target module')
+  .argument('<name>', 'Name of the use case')
+  .argument('<operation>', 'Operation of the use case')
+  .action(async (moduleName, useCaseName, operation) => {
+    if (
+      moduleName === undefined ||
+      useCaseName === undefined ||
+      operation === undefined
+    ) {
+      throw new Error('moduleName, useCaseName, operation is required');
+    }
+    if (operation !== 'query' && operation !== 'command') {
+      throw new Error('operation must be a command or query');
+    }
+
+    const useCaseDir = path.resolve(
+      process.cwd(),
+      'src',
+      'modules',
+      moduleName,
+      'use-cases',
+      useCaseName,
+    );
+
+    try {
+      // NestJS CLI 명령어 실행
+      await runCommand(
+        `nest g module ${useCaseName} modules/${moduleName}/use-cases`,
+      );
+      await runCommand(
+        `nest g controller ${useCaseName} modules/${moduleName}/use-cases`,
+      );
+      await runCommand(
+        `nest g service ${useCaseName} modules/${moduleName}/use-cases`,
+      );
+
+      await runCommand(
+        `mv ${useCaseDir}/${useCaseName}.service.ts ${useCaseDir}/${useCaseName}.handler.ts`,
+      );
+      await runCommand(`mkdir ${useCaseDir}/__spec__`);
+      await runCommand(
+        `mv ${useCaseDir}/${useCaseName}.service.spec.ts ${useCaseDir}/__spec__/${useCaseName}.handler.spec.ts`,
+      );
+      await runCommand(
+        `touch ${useCaseDir}/__spec__/${useCaseName}-${operation}.factory.ts`,
+      );
+      await runCommand(`touch ${useCaseDir}/${useCaseName}.${operation}.ts`);
+
+      const REGEXP_MAP = [
+        ['module-name', moduleName],
+
+        ['use-case-name', useCaseName],
+        ['UseCaseName', pascalCase(useCaseName)],
+        ['useCaseName', camelCase(useCaseName)],
+        ['USE_CASE_NAME', snakeCase(useCaseName).toUpperCase()],
+
+        ['operation-name', operation],
+        ['OperationName', pascalCase(operation)],
+        ['operationName', operation],
+      ];
+
+      const reconfigureFile = (preset: string) => {
+        return REGEXP_MAP.reduce((acc, [key, value]) => {
+          const regexp = new RegExp(key, 'gm');
+          return acc.replace(regexp, value);
+        }, preset);
+      };
+
+      const modulePath = `${useCaseDir}/${useCaseName}.module.ts`;
+      const controllerPath = `${useCaseDir}/${useCaseName}.controller.ts`;
+      const operationPath = `${useCaseDir}/${useCaseName}.${operation}.ts`;
+      const handlerPath = `${useCaseDir}/${useCaseName}.handler.ts`;
+      const handlerSpecPath = `${useCaseDir}/__spec__/${useCaseName}.handler.spec.ts`;
+      const factoryPath = `${useCaseDir}/__spec__/${useCaseName}-${operation}.factory.ts`;
+      const dtoPath = `${useCaseDir}/${useCaseName}.dto.ts`;
+      writeFileSync(modulePath, reconfigureFile(PRESETS.MODULE_PRESET));
+      writeFileSync(controllerPath, reconfigureFile(PRESETS.CONTROLLER_PRESET));
+      writeFileSync(handlerPath, reconfigureFile(PRESETS.HANDLER_PRESET));
+      writeFileSync(operationPath, reconfigureFile(PRESETS.OPERATION_PRESET));
+      writeFileSync(
+        handlerSpecPath,
+        reconfigureFile(PRESETS.HANDLER_SPEC_PRESET),
+      );
+      writeFileSync(
+        factoryPath,
+        reconfigureFile(PRESETS.FACTORY_OPERATION_PRESET),
+      );
+
+      if (operation === 'command') {
+        await runCommand(`touch ${useCaseDir}/${useCaseName}.dto.ts`);
+        writeFileSync(dtoPath, reconfigureFile(PRESETS.DTO_PRESET));
+        await runCommand(`npx prettier --write ${dtoPath}`);
+      }
+
+      await runCommand(
+        `npx prettier --write ${modulePath} ${controllerPath} ${operationPath} ${handlerPath} ${handlerSpecPath} ${factoryPath}`,
+      );
+
+      console.log(`Use case '${useCaseName}' generated successfully.`);
+    } catch (error) {
+      console.error('Failed to generate use case:', error);
+    }
+  });
+
+// 프로그램 실행
+program.parse(process.argv);

--- a/src/common/base/base.repository.ts
+++ b/src/common/base/base.repository.ts
@@ -41,8 +41,6 @@ export abstract class BaseRepository<
   Raw extends { id: bigint },
 > implements Omit<RepositoryPort<Entity>, 'findAllCursorPaginated'>
 {
-  protected abstract TABLE_NAME: string;
-
   constructor(
     protected readonly em: EntityManager,
     protected readonly entityName: EntityName<any>,


### PR DESCRIPTION
### Short description

반복 작업을 줄이기 위한 코드베이스 생성 스크립트

### Proposed changes

- 도메인 생성 스크립트 추가
- 유즈케이스 생성 스크립트 추가
- 베이스 리포지토리 수정

### How to test (Optional)

```bash
# account 도메인에 필요한 디렉토리 및 파일  생성
npm run gen:domain account account 
# create-account usecase에 필요한 디렉토리 및 파일 생성
npm run gen:usecase -- account create-account command
# get-account usecase에 필요한 디렉토리 및 파일 생성
npm run gen:usecase -- account get-account query
```

### Reference (Optional)

Closes #6 
