### PR TITLE
이벤트 소싱 적용

### DIFF
--- a/prisma/migrations/20250629105842_account_event_store/migration.sql
+++ b/prisma/migrations/20250629105842_account_event_store/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "account_event_store" (
+    "id" BIGINT NOT NULL,
+    "actorId" BIGINT,
+    "aggregateId" BIGINT NOT NULL,
+    "eventName" TEXT NOT NULL,
+    "eventPayload" JSONB NOT NULL,
+    "version" INTEGER NOT NULL,
+    "storedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "account_event_store_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "account_event_store_aggregateId_version_key" ON "account_event_store"("aggregateId", "version");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,3 +36,17 @@ model Account {
 
   @@map("account")
 }
+
+model AccountEventStore {
+  id           BigInt   @id
+  actorId      BigInt?
+  aggregateId  BigInt
+  eventName    String
+  eventPayload Json
+  version      Int
+  storedAt     DateTime @default(now()) @db.Timestamp(3)
+
+  @@unique([aggregateId, version])
+
+  @@map("account_event_store")
+}

--- a/src/core/event-sourcing/event-store.interface.ts
+++ b/src/core/event-sourcing/event-store.interface.ts
@@ -1,0 +1,10 @@
+import { DomainEvent } from '@common/base/base.domain-event';
+import { AggregateRoot } from '@common/base/base.entity';
+
+export const EVENT_STORE = Symbol('EVENT_STORE');
+
+export interface IEventStore {
+  storeAggregateEvents(
+    aggregateRoot: AggregateRoot<unknown>,
+  ): Promise<DomainEvent[]>;
+}

--- a/src/core/event-sourcing/event-store.module.ts
+++ b/src/core/event-sourcing/event-store.module.ts
@@ -1,0 +1,25 @@
+import { Global, Module } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+
+import { PrismaModule } from '@shared/prisma/prisma.module';
+
+import { EventStore } from '@core/event-sourcing/event-store';
+import { EVENT_STORE } from '@core/event-sourcing/event-store.interface';
+
+@Global()
+@Module({
+  imports: [
+    PrismaModule,
+    EventEmitterModule.forRoot({
+      global: false,
+    }),
+  ],
+  providers: [
+    {
+      provide: EVENT_STORE,
+      useClass: EventStore,
+    },
+  ],
+  exports: [EVENT_STORE],
+})
+export class EventStoreModule {}

--- a/src/core/event-sourcing/event-store.ts
+++ b/src/core/event-sourcing/event-store.ts
@@ -1,0 +1,75 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+import { DomainEvent } from '@common/base/base.domain-event';
+import { AggregateRoot, generateEntityId } from '@common/base/base.entity';
+
+import { PRISMA_SERVICE } from '@shared/prisma/prisma.di-token';
+import { PrismaService } from '@shared/prisma/prisma.service';
+
+import { IEventStore } from '@core/event-sourcing/event-store.interface';
+
+@Injectable()
+export class EventStore implements IEventStore {
+  constructor(
+    @Inject(PRISMA_SERVICE) private readonly prismaService: PrismaService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async storeAggregateEvents(
+    aggregateRoot: AggregateRoot<unknown>,
+  ): Promise<DomainEvent[]> {
+    const events = aggregateRoot.getUncommittedEvents();
+    if (events.length === 0) {
+      return [];
+    }
+
+    const aggregate = events[0].aggregate;
+
+    const repository = this.getRepository(aggregate);
+
+    if (repository === undefined) {
+      return events;
+    }
+
+    const result = await (repository as any).findFirst({
+      select: {
+        version: true,
+      },
+      where: {
+        aggregateId: BigInt(aggregateRoot.id),
+      },
+      orderBy: {
+        id: 'desc',
+      },
+    });
+
+    const version = result?.version || 0;
+
+    console.log(events);
+    await repository.createMany({
+      data: events.map((event, idx) => {
+        return {
+          id: BigInt(generateEntityId()),
+          actorId:
+            event.actorId === undefined ? undefined : BigInt(event.actorId),
+          aggregateId: BigInt(event.aggregateId),
+          eventName: event.eventName,
+          eventPayload: event.eventPayload,
+          version: version + idx + 1,
+          storedAt: event.storedAt,
+        };
+      }),
+    });
+
+    events.forEach((event) => this.eventEmitter.emit(event.eventName, event));
+
+    return events;
+  }
+
+  private getRepository(aggregate: DomainEvent['aggregate']) {
+    if (aggregate === 'Account') {
+      return this.prismaService.accountEventStore;
+    }
+  }
+}

--- a/src/modules/account/use-cases/create-account/__spec__/create-account.handler.spec.ts
+++ b/src/modules/account/use-cases/create-account/__spec__/create-account.handler.spec.ts
@@ -11,6 +11,8 @@ import { CreateAccountCommandFactory } from '@module/account/use-cases/create-ac
 import { CreateAccountCommand } from '@module/account/use-cases/create-account/create-account.command';
 import { CreateAccountHandler } from '@module/account/use-cases/create-account/create-account.handler';
 
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
 describe(CreateAccountHandler.name, () => {
   let handler: CreateAccountHandler;
   let accountRepository: AccountRepositoryPort;
@@ -19,7 +21,7 @@ describe(CreateAccountHandler.name, () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [AccountRepositoryModule],
+      imports: [AccountRepositoryModule, EventStoreModule],
       providers: [CreateAccountHandler],
     }).compile();
 

--- a/src/modules/account/use-cases/create-account/create-account.handler.ts
+++ b/src/modules/account/use-cases/create-account/create-account.handler.ts
@@ -9,6 +9,11 @@ import {
 } from '@module/account/repositories/account/account.repository.port';
 import { CreateAccountCommand } from '@module/account/use-cases/create-account/create-account.command';
 
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+
 @CommandHandler(CreateAccountCommand)
 export class CreateAccountHandler
   implements ICommandHandler<CreateAccountCommand, Account>
@@ -16,16 +21,10 @@ export class CreateAccountHandler
   constructor(
     @Inject(ACCOUNT_REPOSITORY)
     private readonly accountRepository: AccountRepositoryPort,
+    @Inject(EVENT_STORE) private readonly eventStore: IEventStore,
   ) {}
 
   async execute(command: CreateAccountCommand): Promise<Account> {
-    const account = Account.create({
-      role: command.role,
-      signInType: command.signInType,
-      username: command.username,
-      password: command.password,
-    });
-
     const existingAccount = await this.accountRepository.findOneByUsername(
       command.username,
     );
@@ -34,7 +33,16 @@ export class CreateAccountHandler
       throw new AccountUsernameAlreadyOccupiedError();
     }
 
+    const account = Account.create({
+      role: command.role,
+      signInType: command.signInType,
+      username: command.username,
+      password: command.password,
+    });
+
     await this.accountRepository.insert(account);
+
+    await this.eventStore.storeAggregateEvents(account);
 
     return account;
   }

--- a/src/modules/account/use-cases/create-account/create-account.module.ts
+++ b/src/modules/account/use-cases/create-account/create-account.module.ts
@@ -3,8 +3,10 @@ import { Module } from '@nestjs/common';
 import { AccountRepositoryModule } from '@module/account/repositories/account/account.repository.module';
 import { CreateAccountHandler } from '@module/account/use-cases/create-account/create-account.handler';
 
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
 @Module({
-  imports: [AccountRepositoryModule],
+  imports: [AccountRepositoryModule, EventStoreModule],
   providers: [CreateAccountHandler],
 })
 export class CreateAccountModule {}

--- a/test/after-env-setup.ts
+++ b/test/after-env-setup.ts
@@ -5,7 +5,7 @@ jest.mock('nestjs-request-context', () => ({
     currentContext: {
       req: {
         user: {
-          id: faker.string.uuid(),
+          id: faker.string.numeric(),
         },
       },
     },


### PR DESCRIPTION
### Short description

이벤트 소싱을 적용하기 위해 이벤트 스토어 구현 및 계정 생성 시 이벤트를 저장

### Proposed changes

- 이벤트 스토어 구현
- 계정 생성 시 이벤트를 저장

### How to test (Optional)

회원가입 후에 이벤트 스토어에 계정 생성됨 이벤트가 저장됐는지 확인

```bash
curl --location --request POST 'http://localhost:3000/auth/sign-up/username' \
--header 'Content-Type: application/json' \
--data '{
  "username": "username1",
  "password": "qwer1234"
}'
```

### Reference (Optional)

Closes #14
