### PR TITLE
사용자 로그인 시 로그인 이벤트 수집

### DIFF
--- a/prisma/migrations/20250821062913_account_last_signed_in_at/migration.sql
+++ b/prisma/migrations/20250821062913_account_last_signed_in_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "account" ADD COLUMN     "lastSignedInAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,9 +28,10 @@ model Account {
   role       AccountRole
   signInType SignInType
 
-  username      String?   @unique @db.VarChar(20)
-  password      String?
-  lastEnteredAt DateTime? @db.Timestamp(3)
+  username       String?   @unique @db.VarChar(20)
+  password       String?
+  lastEnteredAt  DateTime? @db.Timestamp(3)
+  lastSignedInAt DateTime? @db.Timestamp(3)
 
   createdAt DateTime @default(now()) @db.Timestamp(3)
   updatedAt DateTime @updatedAt @db.Timestamp(3)

--- a/src/modules/account/entities/account.entity.ts
+++ b/src/modules/account/entities/account.entity.ts
@@ -1,5 +1,6 @@
 import { AccountCreatedEvent } from '@module/account/events/account-created-event/account-created.event';
 import { AccountEnteredEvent } from '@module/account/events/account-entered-event/account-entered.event';
+import { AccountSignedInEvent } from '@module/account/events/account-signed-in-event/account-signed-in.event';
 
 import {
   AggregateRoot,
@@ -22,6 +23,7 @@ export interface AccountProps {
   username?: string;
   password?: string;
   enteredAt?: Date;
+  lastSignedInAt?: Date;
 }
 
 interface CreateAccountProps {
@@ -94,5 +96,15 @@ export class Account extends AggregateRoot<AccountProps> {
     this.updatedAt = now;
 
     this.apply(new AccountEnteredEvent(this.id, { enteredAt: now }));
+  }
+
+  signIn() {
+    const now = new Date();
+
+    this.props.lastSignedInAt = now;
+
+    this.updatedAt = now;
+
+    this.apply(new AccountSignedInEvent(this.id, { signedInAt: now }));
   }
 }

--- a/src/modules/account/events/account-signed-in-event/account-signed-in.event.ts
+++ b/src/modules/account/events/account-signed-in-event/account-signed-in.event.ts
@@ -1,0 +1,9 @@
+import { DomainEvent } from '@common/base/base.domain-event';
+
+interface AccountSignedInEventPayload {
+  signedInAt: Date;
+}
+
+export class AccountSignedInEvent extends DomainEvent<AccountSignedInEventPayload> {
+  readonly aggregate = 'Account';
+}

--- a/src/modules/account/mappers/account.mapper.ts
+++ b/src/modules/account/mappers/account.mapper.ts
@@ -19,6 +19,7 @@ export class AccountMapper extends BaseMapper {
         username: raw.username ?? undefined,
         password: raw.password ?? undefined,
         enteredAt: raw.lastEnteredAt ?? undefined,
+        lastSignedInAt: raw.lastSignedInAt ?? undefined,
       },
     });
   }
@@ -33,6 +34,7 @@ export class AccountMapper extends BaseMapper {
       username: entity.props.username ?? null,
       password: entity.props.password ?? null,
       lastEnteredAt: entity.props.enteredAt ?? null,
+      lastSignedInAt: entity.props.lastSignedInAt ?? null,
     };
   }
 }

--- a/src/modules/auth/use-cases/sign-in-with-username/__spec__/sign-in-with-username.handler.spec.ts
+++ b/src/modules/auth/use-cases/sign-in-with-username/__spec__/sign-in-with-username.handler.spec.ts
@@ -13,6 +13,8 @@ import { SignInWithUsernameCommandFactory } from '@module/auth/use-cases/sign-in
 import { SignInWithUsernameCommand } from '@module/auth/use-cases/sign-in-with-username/sign-in-with-username.command';
 import { SignInWithUsernameHandler } from '@module/auth/use-cases/sign-in-with-username/sign-in-with-username.handler';
 
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
 describe(SignInWithUsernameHandler, () => {
   let handler: SignInWithUsernameHandler;
 
@@ -22,7 +24,7 @@ describe(SignInWithUsernameHandler, () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [CqrsModule, AuthTokenModule],
+      imports: [CqrsModule, AuthTokenModule, EventStoreModule],
       providers: [SignInWithUsernameHandler],
     }).compile();
 


### PR DESCRIPTION
### Short description

사용자의 이벤트 로그를 수집하기 위해 로그인 시 로그인 이벤트 저장

### Proposed changes

- 유저네임 로그인 시 사인 인 이벤트 수집

### How to test (Optional)

```bash
curl -X 'POST' \
  'http://localhost:3000/auth/sign-in/username' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "username": "seokho1",
  "password": "seokho1"
}'
```

### Reference (Optional)

Closes #31 
