### PR TITLE
async api document에서 enum이 스키마를 참조하는 않는 문제 수정

### DIFF
--- a/src/modules/game-room/events/game-room-member-joined/game-room-member-joined-socket.event.ts
+++ b/src/modules/game-room/events/game-room-member-joined/game-room-member-joined-socket.event.ts
@@ -13,6 +13,7 @@ class GameRoomMemberJoinedSocketEventBody {
 
   @ApiProperty({
     enum: GameRoomMemberRole,
+    enumName: 'GameRoomMemberRole',
   })
   role: GameRoomMemberRole;
 


### PR DESCRIPTION
### Short description

async api document에서 enum이 스키마를 참조하는 않는 문제 수정

### Proposed changes

- GameRoomMemberJoinedSocketEventBody.role 필드가 스키마를 참조하게 변경

### How to test (Optional)

http://localhost:3000/async-doc-json 확인하여 GameRoomMemberJoinedSocketEventBody.role가 ref로 스키마를 참조하는지 확인

### Reference (Optional)

Closes #43 
