### PR TITLE
async api role 문서화 시 타이틀 추가

### DIFF
--- a/src/modules/game-room/events/game-room-member-joined/game-room-member-joined-socket.event.ts
+++ b/src/modules/game-room/events/game-room-member-joined/game-room-member-joined-socket.event.ts
@@ -12,6 +12,7 @@ class GameRoomMemberJoinedSocketEventBody {
   gameRoomId: string;
 
   @ApiProperty({
+    title: 'GameRoomMemberRole',
     enum: GameRoomMemberRole,
     enumName: 'GameRoomMemberRole',
   })


### PR DESCRIPTION
### Short description

async api role 문서화 시 타이틀 추가
프론트엔드 코드젠 시 title로 enum이름을 생성하기에 추가

### Proposed changes

- 구성원 조인 이벤트 페이로드의 role title 추가

### How to test (Optional)

http://localhost:3000/async-api-json에서 role에 title이 있는지 확인

### Reference (Optional)

Closes #43 
