### PR TITLE
계정 속성에 nickname 추가

### DIFF
--- a/prisma/migrations/20250824073350_account_nickname/migration.sql
+++ b/prisma/migrations/20250824073350_account_nickname/migration.sql
@@ -1,0 +1,19 @@
+/*
+  마이그레이션 절차:
+  1) 닉네임 컬럼 추가 (nullable)
+  2) 기존 row의 nickname = id::text 로 백필
+  3) NOT NULL + UNIQUE 제약 추가
+*/
+
+-- Step 1
+ALTER TABLE "account" ADD COLUMN "nickname" VARCHAR(20);
+
+-- Step 2
+UPDATE "account"
+SET "nickname" = "id"::text
+WHERE "nickname" IS NULL;
+
+-- Step 3
+ALTER TABLE "account" ALTER COLUMN "nickname" SET NOT NULL;
+
+CREATE UNIQUE INDEX "account_nickname_key" ON "account"("nickname");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Account {
 
   username       String?   @unique @db.VarChar(20)
   password       String?
+  nickname       String    @unique @db.VarChar(20)
   lastEnteredAt  DateTime? @db.Timestamp(3)
   lastSignedInAt DateTime? @db.Timestamp(3)
 

--- a/src/modules/account/assemblers/account-dto.assembler.ts
+++ b/src/modules/account/assemblers/account-dto.assembler.ts
@@ -11,6 +11,7 @@ export class AccountDtoAssembler {
 
     dto.role = account.role;
     dto.signInType = account.signInType;
+    dto.nickname = account.nickname;
     dto.enteredAt = account.enteredAt;
 
     return dto;

--- a/src/modules/account/dto/account.dto.ts
+++ b/src/modules/account/dto/account.dto.ts
@@ -20,6 +20,9 @@ export class AccountDto extends BaseResponseDto {
   })
   signInType: SignInType;
 
+  @ApiProperty()
+  nickname: string;
+
   @ApiProperty({
     description: '진입 시점',
   })

--- a/src/modules/account/entities/__spec__/account.factory.ts
+++ b/src/modules/account/entities/__spec__/account.factory.ts
@@ -19,6 +19,7 @@ export const AccountFactory = Factory.define<Account & AccountProps>(
     signInType: () => faker.helpers.arrayElement(Object.values(SignInType)),
     username: () => faker.internet.username(),
     password: () => faker.internet.password(),
+    nickname: () => generateEntityId(),
     enteredAt: () => faker.date.past(),
     createdAt: () => new Date(),
     updatedAt: () => new Date(),

--- a/src/modules/account/entities/account.entity.ts
+++ b/src/modules/account/entities/account.entity.ts
@@ -22,6 +22,7 @@ export interface AccountProps {
   signInType: SignInType;
   username?: string;
   password?: string;
+  nickname: string;
   enteredAt?: Date;
   lastSignedInAt?: Date;
 }
@@ -29,6 +30,7 @@ export interface AccountProps {
 interface CreateAccountProps {
   role: AccountRole;
   signInType: SignInType;
+  nickname?: string;
   username?: string;
   password?: string;
 }
@@ -49,6 +51,7 @@ export class Account extends AggregateRoot<AccountProps> {
         signInType: props.signInType,
         username: props.username,
         password: props.password,
+        nickname: props.nickname ?? generateEntityId(),
       },
       createdAt: date,
       updatedAt: date,
@@ -60,6 +63,7 @@ export class Account extends AggregateRoot<AccountProps> {
         signInType: props.signInType,
         username: props.username,
         password: props.password,
+        nickname: account.props.nickname,
       }),
     );
 
@@ -82,6 +86,10 @@ export class Account extends AggregateRoot<AccountProps> {
 
   get password(): string | undefined {
     return this.props.password;
+  }
+
+  get nickname(): string {
+    return this.props.nickname;
   }
 
   get enteredAt(): Date | undefined {

--- a/src/modules/account/entities/account.entity.ts
+++ b/src/modules/account/entities/account.entity.ts
@@ -103,7 +103,12 @@ export class Account extends AggregateRoot<AccountProps> {
 
     this.updatedAt = now;
 
-    this.apply(new AccountEnteredEvent(this.id, { enteredAt: now }));
+    this.apply(
+      new AccountEnteredEvent(this.id, {
+        nickname: this.props.nickname,
+        enteredAt: now,
+      }),
+    );
   }
 
   signIn() {

--- a/src/modules/account/errors/account-nickname-already-occupied.error.ts
+++ b/src/modules/account/errors/account-nickname-already-occupied.error.ts
@@ -1,0 +1,12 @@
+import { BaseError } from '@common/base/base.error';
+
+export class AccountNicknameAlreadyOccupiedError extends BaseError {
+  static CODE: string = 'ACCOUNT.NICKNAME_ALREADY_OCCUPIED';
+
+  constructor(message?: string) {
+    super(
+      message ?? 'Account nickname is already occupied',
+      AccountNicknameAlreadyOccupiedError.CODE,
+    );
+  }
+}

--- a/src/modules/account/events/account-created-event/account-created.event.ts
+++ b/src/modules/account/events/account-created-event/account-created.event.ts
@@ -10,6 +10,7 @@ interface AccountCreatedEventPayload {
   signInType: SignInType;
   username?: string;
   password?: string;
+  nickname: string;
 }
 
 export class AccountCreatedEvent extends DomainEvent<AccountCreatedEventPayload> {

--- a/src/modules/account/events/account-entered-event/__spec__/account-entered.handler.spec.ts
+++ b/src/modules/account/events/account-entered-event/__spec__/account-entered.handler.spec.ts
@@ -54,6 +54,7 @@ describe(AccountEnteredHandler, () => {
 
   beforeEach(() => {
     event = new AccountEnteredEvent(generateEntityId(), {
+      nickname: generateEntityId(),
       enteredAt: new Date(),
     });
   });

--- a/src/modules/account/events/account-entered-event/account-entered.event.ts
+++ b/src/modules/account/events/account-entered-event/account-entered.event.ts
@@ -1,6 +1,7 @@
 import { DomainEvent } from '@common/base/base.domain-event';
 
 interface AccountEnteredEventPayload {
+  nickname: string;
   enteredAt: Date;
 }
 

--- a/src/modules/account/events/account-entered-event/account-entered.handler.ts
+++ b/src/modules/account/events/account-entered-event/account-entered.handler.ts
@@ -32,6 +32,7 @@ export class AccountEnteredHandler {
     const socketEvent = new AccountEnteredSocketEvent({
       account: {
         id: event.aggregateId,
+        nickname: event.eventPayload.nickname,
         enteredAt: event.eventPayload.enteredAt,
       },
       currentActiveAccountsCount,

--- a/src/modules/account/mappers/account.mapper.ts
+++ b/src/modules/account/mappers/account.mapper.ts
@@ -18,6 +18,7 @@ export class AccountMapper extends BaseMapper {
         signInType: SignInType[raw.signInType],
         username: raw.username ?? undefined,
         password: raw.password ?? undefined,
+        nickname: raw.nickname,
         enteredAt: raw.lastEnteredAt ?? undefined,
         lastSignedInAt: raw.lastSignedInAt ?? undefined,
       },
@@ -33,6 +34,7 @@ export class AccountMapper extends BaseMapper {
       signInType: entity.props.signInType,
       username: entity.props.username ?? null,
       password: entity.props.password ?? null,
+      nickname: entity.props.nickname,
       lastEnteredAt: entity.props.enteredAt ?? null,
       lastSignedInAt: entity.props.lastSignedInAt ?? null,
     };

--- a/src/modules/account/repositories/account/__spec__/account.repository.spec.ts
+++ b/src/modules/account/repositories/account/__spec__/account.repository.spec.ts
@@ -90,4 +90,36 @@ describe(AccountRepository, () => {
       });
     });
   });
+
+  describe(AccountRepository.prototype.findOneByNickname, () => {
+    let nickname: string;
+
+    beforeEach(() => {
+      nickname = generateEntityId();
+    });
+
+    describe('넥네임과 일치하는 계정이 존재하면', () => {
+      let account: Account;
+
+      beforeEach(async () => {
+        account = await repository.insert(
+          AccountFactory.build({ nickname: nickname }),
+        );
+      });
+
+      it('계정이 반환돼야한다.', async () => {
+        await expect(repository.findOneByNickname(nickname)).resolves.toEqual(
+          account,
+        );
+      });
+    });
+
+    describe('닉네임과 일치하는 계정이 존재하지 않으면', () => {
+      it('undefined가 반환돼야한다.', async () => {
+        await expect(
+          repository.findOneByNickname(nickname),
+        ).resolves.toBeUndefined();
+      });
+    });
+  });
 });

--- a/src/modules/account/repositories/account/account.repository.port.ts
+++ b/src/modules/account/repositories/account/account.repository.port.ts
@@ -15,4 +15,5 @@ export interface AccountOrder {}
 export interface AccountRepositoryPort
   extends RepositoryPort<Account, AccountFilter, AccountOrder> {
   findOneByUsername(username: string): Promise<Account | undefined>;
+  findOneByNickname(nickname: string): Promise<Account | undefined>;
 }

--- a/src/modules/account/repositories/account/account.repository.ts
+++ b/src/modules/account/repositories/account/account.repository.ts
@@ -45,6 +45,20 @@ export class AccountRepository
     return this.mapper.toEntity(account);
   }
 
+  async findOneByNickname(nickname: string): Promise<Account | undefined> {
+    const account = await this.prismaService.account.findFirst({
+      where: {
+        nickname,
+      },
+    });
+
+    if (account === null) {
+      return;
+    }
+
+    return this.mapper.toEntity(account);
+  }
+
   findAllCursorPaginated(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     params: ICursorPaginatedParams<AccountOrder, AccountFilter>,

--- a/src/modules/account/socket-events/account-entered-socket.event.ts
+++ b/src/modules/account/socket-events/account-entered-socket.event.ts
@@ -7,6 +7,9 @@ class AccountEnteredSocketEventBodyAccount {
   id: string;
 
   @ApiProperty()
+  nickname: string;
+
+  @ApiProperty()
   enteredAt: Date;
 }
 

--- a/src/modules/account/use-cases/create-account/__spec__/create-account-command.factory.ts
+++ b/src/modules/account/use-cases/create-account/__spec__/create-account-command.factory.ts
@@ -7,6 +7,8 @@ import {
 } from '@module/account/entities/account.entity';
 import { CreateAccountCommand } from '@module/account/use-cases/create-account/create-account.command';
 
+import { generateEntityId } from '@common/base/base.entity';
+
 export const CreateAccountCommandFactory = Factory.define<CreateAccountCommand>(
   CreateAccountCommand.name,
   CreateAccountCommand,
@@ -15,4 +17,5 @@ export const CreateAccountCommandFactory = Factory.define<CreateAccountCommand>(
   signInType: () => faker.helpers.arrayElement(Object.values(SignInType)),
   username: () => faker.string.nanoid(20),
   password: () => faker.internet.password(),
+  nickname: () => generateEntityId(),
 });

--- a/src/modules/account/use-cases/create-account/__spec__/create-account.handler.spec.ts
+++ b/src/modules/account/use-cases/create-account/__spec__/create-account.handler.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { AccountFactory } from '@module/account/entities/__spec__/account.factory';
+import { AccountNicknameAlreadyOccupiedError } from '@module/account/errors/account-nickname-already-occupied.error';
 import { AccountUsernameAlreadyOccupiedError } from '@module/account/errors/account-username-already-occupied.error';
 import { AccountRepositoryModule } from '@module/account/repositories/account/account.repository.module';
 import {
@@ -55,6 +56,20 @@ describe(CreateAccountHandler.name, () => {
     it('동일한 유저네임을 가진 계정이 이미 존재한다는 에러가 발생해야한다.', async () => {
       await expect(handler.execute(command)).rejects.toThrow(
         AccountUsernameAlreadyOccupiedError,
+      );
+    });
+  });
+
+  describe('동일한 닉네임을 가진 계정이 존재하면', () => {
+    beforeEach(async () => {
+      await accountRepository.insert(
+        AccountFactory.build({ nickname: command.nickname }),
+      );
+    });
+
+    it('동일한 닉네임을 가진 계정이 존재한다는 에러가 발생해야한다.', async () => {
+      await expect(handler.execute(command)).rejects.toThrow(
+        AccountNicknameAlreadyOccupiedError,
       );
     });
   });

--- a/src/modules/account/use-cases/create-account/create-account.command.ts
+++ b/src/modules/account/use-cases/create-account/create-account.command.ts
@@ -10,6 +10,7 @@ export interface ICreateAccountCommandProps {
   signInType: SignInType;
   username: string;
   password: string;
+  nickname?: string;
 }
 
 export class CreateAccountCommand implements ICommand {
@@ -17,11 +18,13 @@ export class CreateAccountCommand implements ICommand {
   readonly signInType: SignInType;
   readonly username: string;
   readonly password: string;
+  readonly nickname?: string;
 
   constructor(props: ICreateAccountCommandProps) {
     this.role = props.role;
     this.signInType = props.signInType;
     this.username = props.username;
     this.password = props.password;
+    this.nickname = props.nickname;
   }
 }


### PR DESCRIPTION
### Short description

계정 속성에 nickname 추가

### Proposed changes

- 계정 스키마에 nickname 추가
- tsid로 무작위 생성되게끔 함
- 계정 응답으로 nickname 추가
- account entered socket event에 nickname 추가

### How to test (Optional)

계정 생성 후 nickname 필드가 생성되는지 확인

```bash
curl -X 'POST' \
  'http://localhost:3000/auth/sign-up/username' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "username": "seokho2",
  "password": "seokho2"
}'
```

### Reference (Optional)

Closes #47
