### PR TITLE
게임방 퇴장 API

### DIFF
--- a/socket-test.html
+++ b/socket-test.html
@@ -32,8 +32,8 @@
           style="width: 200px"
         />
       </label>
-      <button id="subscribeBtn">Subscribe (game_room.subscribe)</button>
-      <button id="unsubscribeBtn">Unsubscribe</button>
+      <button id="joinBtn">Join Room (game_room.subscribe)</button>
+      <button id="leaveBtn">Leave Room (game_room.leave)</button>
     </div>
 
     <pre
@@ -59,42 +59,72 @@
 
       // Connect
       document.getElementById('connectBtn').addEventListener('click', () => {
+        if (socket) {
+          log('Already connected. Disconnect first.');
+          return;
+        }
         const token = document.getElementById('token').value;
 
         socket = io('http://localhost:3000', {
-          auth: { token: `Bearer ${token}` }, // 서버에서 Bearer 파싱한다면 "Bearer xxx" 형태로 넣기
-          transports: ['websocket'], // 필요 시 제거 가능
+          auth: { token: `Bearer ${token}` },
+          transports: ['websocket'],
         });
 
         socket.on('connect', () => log('[connect]', socket.id));
-        socket.on('disconnect', (reason) => log('[disconnect]', reason));
+        socket.on('disconnect', (reason) => {
+          log('[disconnect]', reason);
+          socket = null;
+        });
         socket.on('exception', (err) => log('[exception]', err));
         socket.on('connect_error', (err) =>
           log('[connect_error]', err.message),
         );
 
-        // ✅ 게임룸 입장 브로드캐스트 수신
-        // 서버 퍼블리시 이벤트명: game_room.member_joined
+        // --- Game Room Events ---
         socket.on('game_room.member_joined', (payload) => {
           log('[game_room.member_joined]', payload);
         });
-
-        // 참고: 계정 입장 이벤트 수신 (있다면)
-        socket.on('account.entered', (payload) =>
-          log('[account.entered]', payload),
-        );
+        socket.on('game_room.member_left', (payload) => {
+          log('[game_room.member_left]', payload);
+        });
+        socket.on('game_room.member_role_changed', (payload) => {
+          log('[game_room.member_role_changed]', payload);
+        });
+        socket.on('game_room.closed', (payload) => {
+          log('[game_room.closed]', payload);
+        });
       });
 
-      // Subscribe (game_room.subscribe)
-      document.getElementById('subscribeBtn').addEventListener('click', () => {
+      // Disconnect
+      document.getElementById('disconnectBtn').addEventListener('click', () => {
+        if (socket && socket.connected) {
+          socket.disconnect();
+        } else {
+          log('Not connected.');
+        }
+      });
+
+      // Join Room (game_room.subscribe)
+      document.getElementById('joinBtn').addEventListener('click', () => {
         if (!socket || !socket.connected) return log('Socket is not connected');
 
         const roomId = getRoomId();
         if (!roomId) return log('roomId is empty');
 
-        // 서버 게이트웨이 @SubscribeMessage('game_room.subscribe')와 일치
         socket.emit('game_room.subscribe', { roomId }, (ack) => {
-          log('[subscribe ack]', ack);
+          log('[game_room.subscribe ack]', ack);
+        });
+      });
+
+      // Leave Room (game_room.leave)
+      document.getElementById('leaveBtn').addEventListener('click', () => {
+        if (!socket || !socket.connected) return log('Socket is not connected');
+
+        const roomId = getRoomId();
+        if (!roomId) return log('roomId is empty');
+
+        socket.emit('game_room.leave', { roomId }, (ack) => {
+          log('[game_room.leave ack]', ack);
         });
       });
     </script>

--- a/src/modules/game-room/entities/game-room-member.entity.ts
+++ b/src/modules/game-room/entities/game-room-member.entity.ts
@@ -61,5 +61,9 @@ export class GameRoomMember extends BaseEntity<GameRoomMemberProps> {
     return this.props.nickname;
   }
 
+  changeRole(role: GameRoomMemberRole) {
+    this.props.role = role;
+  }
+
   public validate(): void {}
 }

--- a/src/modules/game-room/errors/game-room-member-not-found.error.ts
+++ b/src/modules/game-room/errors/game-room-member-not-found.error.ts
@@ -1,0 +1,12 @@
+import { BaseError } from '@common/base/base.error';
+
+export class GameRoomMemberNotFoundError extends BaseError {
+  static CODE: string = 'GAME_ROOM_MEMBER.NOT_FOUND';
+
+  constructor(message?: string) {
+    super(
+      message ?? 'Game Room member not found',
+      GameRoomMemberNotFoundError.CODE,
+    );
+  }
+}

--- a/src/modules/game-room/events/game-room-closed/__spec__/game-room-closed.handler.spec.ts
+++ b/src/modules/game-room/events/game-room-closed/__spec__/game-room-closed.handler.spec.ts
@@ -1,0 +1,56 @@
+import { Test } from '@nestjs/testing';
+import { TestingModule } from '@nestjs/testing/testing-module';
+
+import { GameRoomClosedEvent } from '@module/game-room/events/game-room-closed/game-room-closed.event';
+import { GameRoomClosedHandler } from '@module/game-room/events/game-room-closed/game-room-closed.handler';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+} from '@core/socket/socket-event.emitter.interface';
+
+describe(GameRoomClosedHandler, () => {
+  let handler: GameRoomClosedHandler;
+
+  let socketEmitter: ISocketEventEmitter;
+
+  let event: GameRoomClosedEvent;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [SocketEventEmitterModule],
+      providers: [GameRoomClosedHandler],
+    }).compile();
+
+    handler = module.get<GameRoomClosedHandler>(GameRoomClosedHandler);
+    socketEmitter = module.get<ISocketEventEmitter>(SOCKET_EVENT_EMITTER);
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(socketEmitter, 'emitToNamespace')
+      .mockResolvedValue(undefined as never);
+  });
+
+  beforeEach(async () => {
+    const gameRoomId = generateEntityId();
+    event = new GameRoomClosedEvent(gameRoomId, {
+      gameRoomId,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('게임방이 폐쇄되면', () => {
+    it('소켓 이벤트를 발생시켜야한다.', async () => {
+      await expect(handler.handle(event)).resolves.toBeUndefined();
+
+      expect(socketEmitter.emitToNamespace).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/game-room/events/game-room-closed/game-room-closed-socket.event.ts
+++ b/src/modules/game-room/events/game-room-closed/game-room-closed-socket.event.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { BaseSocketEvent } from '@common/base/base-socket-event';
+
+class GameRoomClosedSocketEventBody {
+  @ApiProperty()
+  gameRoomId: string;
+}
+
+export class GameRoomClosedSocketEvent extends BaseSocketEvent<GameRoomClosedSocketEventBody> {
+  static readonly EVENT_NAME = 'game_room.closed';
+
+  @ApiProperty({ example: GameRoomClosedSocketEvent.EVENT_NAME })
+  readonly eventName: string = GameRoomClosedSocketEvent.EVENT_NAME;
+
+  @ApiProperty({ type: GameRoomClosedSocketEventBody })
+  body: GameRoomClosedSocketEventBody;
+}

--- a/src/modules/game-room/events/game-room-closed/game-room-closed.event.ts
+++ b/src/modules/game-room/events/game-room-closed/game-room-closed.event.ts
@@ -1,0 +1,9 @@
+import { DomainEvent } from '@common/base/base.domain-event';
+
+interface GameRoomClosedEventPayload {
+  gameRoomId: string;
+}
+
+export class GameRoomClosedEvent extends DomainEvent<GameRoomClosedEventPayload> {
+  readonly aggregate = 'GameRoom';
+}

--- a/src/modules/game-room/events/game-room-closed/game-room-closed.handler.ts
+++ b/src/modules/game-room/events/game-room-closed/game-room-closed.handler.ts
@@ -1,0 +1,40 @@
+import { Inject } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { AsyncApi, AsyncApiPub } from 'nestjs-asyncapi';
+
+import { GameRoomClosedSocketEvent } from '@module/game-room/events/game-room-closed/game-room-closed-socket.event';
+import { GameRoomClosedEvent } from '@module/game-room/events/game-room-closed/game-room-closed.event';
+
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+  WS_NAMESPACE,
+} from '@core/socket/socket-event.emitter.interface';
+
+@AsyncApi()
+export class GameRoomClosedHandler {
+  constructor(
+    @Inject(SOCKET_EVENT_EMITTER)
+    private readonly socketEmitter: ISocketEventEmitter,
+  ) {}
+
+  @OnEvent(GameRoomClosedEvent.name)
+  async handle(event: GameRoomClosedEvent): Promise<void> {
+    this.publish(event);
+  }
+
+  @AsyncApiPub({
+    tags: [{ name: 'game_room' }],
+    description: '게임방이 폐쇄됨',
+    channel: GameRoomClosedSocketEvent.EVENT_NAME,
+    message: { payload: GameRoomClosedSocketEvent },
+  })
+  private publish(event: GameRoomClosedEvent): void {
+    const socketEvent = new GameRoomClosedSocketEvent({
+      gameRoomId: event.eventPayload.gameRoomId,
+    });
+
+    this.socketEmitter.emitToNamespace(WS_NAMESPACE.ROOT, socketEvent);
+  }
+}

--- a/src/modules/game-room/events/game-room-closed/game-room-closed.module.ts
+++ b/src/modules/game-room/events/game-room-closed/game-room-closed.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { GameRoomClosedHandler } from '@module/game-room/events/game-room-closed/game-room-closed.handler';
+
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+
+@Module({
+  imports: [SocketEventEmitterModule],
+  providers: [GameRoomClosedHandler],
+})
+export class GameRoomClosedModule {}

--- a/src/modules/game-room/events/game-room-member-left/__spec__/game-room-member-left.handler.spec.ts
+++ b/src/modules/game-room/events/game-room-member-left/__spec__/game-room-member-left.handler.spec.ts
@@ -1,0 +1,96 @@
+import { Test } from '@nestjs/testing';
+import { TestingModule } from '@nestjs/testing/testing-module';
+
+import { GameRoomFactory } from '@module/game-room/entities/__spec__/game-room.factory';
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
+import { GameRoom } from '@module/game-room/entities/game-room.entity';
+import { GameRoomMemberLeftEvent } from '@module/game-room/events/game-room-member-left/game-room-member-left.event';
+import { GameRoomMemberLeftHandler } from '@module/game-room/events/game-room-member-left/game-room-member-left.handler';
+import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+import {
+  GAME_ROOM_REPOSITORY,
+  GameRoomRepositoryPort,
+} from '@module/game-room/repositories/game-room/game-room.repository.port';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+import { CacheModule } from '@shared/cache/cache.module';
+
+import { SocketSessionManagerModule } from '@core/socket/session-manager/socket-session.manager.module';
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+} from '@core/socket/socket-event.emitter.interface';
+
+describe(GameRoomMemberLeftHandler, () => {
+  let handler: GameRoomMemberLeftHandler;
+
+  let gameRoomRepository: GameRoomRepositoryPort;
+  let socketEmitter: ISocketEventEmitter;
+
+  let event: GameRoomMemberLeftEvent;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        GameRoomRepositoryModule,
+        SocketEventEmitterModule,
+        SocketSessionManagerModule,
+        CacheModule,
+      ],
+      providers: [GameRoomMemberLeftHandler],
+    }).compile();
+
+    handler = module.get<GameRoomMemberLeftHandler>(GameRoomMemberLeftHandler);
+    gameRoomRepository =
+      module.get<GameRoomRepositoryPort>(GAME_ROOM_REPOSITORY);
+    socketEmitter = module.get<ISocketEventEmitter>(SOCKET_EVENT_EMITTER);
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(socketEmitter, 'emitToRoom')
+      .mockResolvedValue(undefined as never);
+    jest.spyOn(gameRoomRepository, 'decrementCurrentMembersCount');
+  });
+
+  let existingGameRoom: GameRoom;
+
+  beforeEach(async () => {
+    const gameRoomId = generateEntityId();
+    event = new GameRoomMemberLeftEvent(gameRoomId, {
+      gameRoomId,
+      accountId: generateEntityId(),
+      memberId: generateEntityId(),
+      role: GameRoomMemberRole.player,
+      nickname: generateEntityId(),
+    });
+
+    existingGameRoom = await gameRoomRepository.insert(
+      GameRoomFactory.build({
+        id: gameRoomId,
+        currentMembersCount: 1,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('게임방에 멤버가 입장하면', () => {
+    it('현재 멤버 수를 1 감소시키고 이벤트를 발생시켜야한다.', async () => {
+      await expect(handler.handle(event)).resolves.toBeUndefined();
+
+      await expect(
+        gameRoomRepository.findOneById(existingGameRoom.id),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          currentMembersCount: existingGameRoom.currentMembersCount - 1,
+        }),
+      );
+      expect(socketEmitter.emitToRoom).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/game-room/events/game-room-member-left/game-room-member-left-socket.event.ts
+++ b/src/modules/game-room/events/game-room-member-left/game-room-member-left-socket.event.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
+
+import { BaseSocketEvent } from '@common/base/base-socket-event';
+
+class GameRoomMemberLeftSocketEventBody {
+  @ApiProperty()
+  accountId: string;
+
+  @ApiProperty()
+  gameRoomId: string;
+
+  @ApiProperty({
+    title: 'GameRoomMemberRole',
+    enum: GameRoomMemberRole,
+    enumName: 'GameRoomMemberRole',
+  })
+  role: GameRoomMemberRole;
+
+  @ApiProperty()
+  nickname: string;
+
+  @ApiProperty()
+  currentMembersCount: number;
+}
+
+export class GameRoomMemberLeftSocketEvent extends BaseSocketEvent<GameRoomMemberLeftSocketEventBody> {
+  static readonly EVENT_NAME = 'game_room.member_left';
+
+  @ApiProperty({ example: GameRoomMemberLeftSocketEvent.EVENT_NAME })
+  readonly eventName: string = GameRoomMemberLeftSocketEvent.EVENT_NAME;
+
+  @ApiProperty({ type: GameRoomMemberLeftSocketEventBody })
+  body: GameRoomMemberLeftSocketEventBody;
+}

--- a/src/modules/game-room/events/game-room-member-left/game-room-member-left.event.ts
+++ b/src/modules/game-room/events/game-room-member-left/game-room-member-left.event.ts
@@ -1,0 +1,15 @@
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
+
+import { DomainEvent } from '@common/base/base.domain-event';
+
+interface GameRoomMemberLeftEventPayload {
+  gameRoomId: string;
+  accountId: string;
+  memberId: string;
+  role: GameRoomMemberRole;
+  nickname: string;
+}
+
+export class GameRoomMemberLeftEvent extends DomainEvent<GameRoomMemberLeftEventPayload> {
+  readonly aggregate = 'GameRoom';
+}

--- a/src/modules/game-room/events/game-room-member-left/game-room-member-left.handler.ts
+++ b/src/modules/game-room/events/game-room-member-left/game-room-member-left.handler.ts
@@ -1,0 +1,74 @@
+import { Inject } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { AsyncApi, AsyncApiPub } from 'nestjs-asyncapi';
+
+import { GameRoomMemberLeftSocketEvent } from '@module/game-room/events/game-room-member-left/game-room-member-left-socket.event';
+import { GameRoomMemberLeftEvent } from '@module/game-room/events/game-room-member-left/game-room-member-left.event';
+import {
+  GAME_ROOM_REPOSITORY,
+  GameRoomRepositoryPort,
+} from '@module/game-room/repositories/game-room/game-room.repository.port';
+
+import {
+  ISocketSessionManager,
+  SOCKET_SESSION_MANAGER,
+} from '@core/socket/session-manager/socket-session.manager.interface';
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+  WS_NAMESPACE,
+} from '@core/socket/socket-event.emitter.interface';
+import { gameRoomKeyOf } from '@core/socket/socket-room.util';
+
+@AsyncApi()
+export class GameRoomMemberLeftHandler {
+  constructor(
+    @Inject(GAME_ROOM_REPOSITORY)
+    private readonly gameRoomRepository: GameRoomRepositoryPort,
+    @Inject(SOCKET_EVENT_EMITTER)
+    private readonly socketEmitter: ISocketEventEmitter,
+    @Inject(SOCKET_SESSION_MANAGER)
+    private readonly socketSessionManager: ISocketSessionManager,
+  ) {}
+
+  @OnEvent(GameRoomMemberLeftEvent.name)
+  async handle(event: GameRoomMemberLeftEvent): Promise<void> {
+    const currentMembersCount =
+      await this.gameRoomRepository.decrementCurrentMembersCount(
+        event.eventPayload.gameRoomId,
+      );
+
+    await this.socketSessionManager.remoteLeaveByAccount(
+      event.eventPayload.accountId,
+      gameRoomKeyOf(event.eventPayload.gameRoomId),
+    );
+
+    this.publish(event, currentMembersCount);
+  }
+
+  @AsyncApiPub({
+    tags: [{ name: 'game_room' }],
+    description: '유저가 게임방에 퇴장',
+    channel: GameRoomMemberLeftSocketEvent.EVENT_NAME,
+    message: { payload: GameRoomMemberLeftSocketEvent },
+  })
+  private publish(
+    event: GameRoomMemberLeftEvent,
+    currentMembersCount: number,
+  ): void {
+    const socketEvent = new GameRoomMemberLeftSocketEvent({
+      accountId: event.eventPayload.accountId,
+      gameRoomId: event.eventPayload.gameRoomId,
+      role: event.eventPayload.role,
+      currentMembersCount,
+      nickname: event.eventPayload.nickname,
+    });
+
+    this.socketEmitter.emitToRoom(
+      WS_NAMESPACE.ROOT,
+      gameRoomKeyOf(event.eventPayload.gameRoomId),
+      socketEvent,
+    );
+  }
+}

--- a/src/modules/game-room/events/game-room-member-left/game-room-member-left.module.ts
+++ b/src/modules/game-room/events/game-room-member-left/game-room-member-left.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+
+import { GameRoomMemberLeftHandler } from '@module/game-room/events/game-room-member-left/game-room-member-left.handler';
+import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+
+import { SocketSessionManagerModule } from '@core/socket/session-manager/socket-session.manager.module';
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+
+@Module({
+  imports: [
+    GameRoomRepositoryModule,
+    SocketEventEmitterModule,
+    SocketSessionManagerModule,
+  ],
+  providers: [GameRoomMemberLeftHandler],
+})
+export class GameRoomMemberLeftModule {}

--- a/src/modules/game-room/events/game-room-member-role-changed/__spec__/game-room-member-role-changed.handler.spec.ts
+++ b/src/modules/game-room/events/game-room-member-role-changed/__spec__/game-room-member-role-changed.handler.spec.ts
@@ -1,0 +1,64 @@
+import { Test } from '@nestjs/testing';
+import { TestingModule } from '@nestjs/testing/testing-module';
+
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
+import { GameRoomMemberRoleChangedEvent } from '@module/game-room/events/game-room-member-role-changed/game-room-member-role-changed.event';
+import { GameRoomMemberRoleChangedHandler } from '@module/game-room/events/game-room-member-role-changed/game-room-member-role-changed.handler';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+import { SocketSessionManagerModule } from '@core/socket/session-manager/socket-session.manager.module';
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+} from '@core/socket/socket-event.emitter.interface';
+
+describe(GameRoomMemberRoleChangedHandler, () => {
+  let handler: GameRoomMemberRoleChangedHandler;
+
+  let socketEmitter: ISocketEventEmitter;
+
+  let event: GameRoomMemberRoleChangedEvent;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [SocketEventEmitterModule, SocketSessionManagerModule],
+      providers: [GameRoomMemberRoleChangedHandler],
+    }).compile();
+
+    handler = module.get<GameRoomMemberRoleChangedHandler>(
+      GameRoomMemberRoleChangedHandler,
+    );
+    socketEmitter = module.get<ISocketEventEmitter>(SOCKET_EVENT_EMITTER);
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(socketEmitter, 'emitToRoom')
+      .mockResolvedValue(undefined as never);
+  });
+
+  beforeEach(async () => {
+    const gameRoomId = generateEntityId();
+    event = new GameRoomMemberRoleChangedEvent(gameRoomId, {
+      gameRoomId,
+      accountId: generateEntityId(),
+      memberId: generateEntityId(),
+      role: GameRoomMemberRole.player,
+      nickname: generateEntityId(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('게임방의 구성원 역할이 변경되면', () => {
+    it('소켓 이벤트를 발생시켜야한다.', async () => {
+      await expect(handler.handle(event)).resolves.toBeUndefined();
+
+      expect(socketEmitter.emitToRoom).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/game-room/events/game-room-member-role-changed/game-room-member-role-changed-socket.event.ts
+++ b/src/modules/game-room/events/game-room-member-role-changed/game-room-member-role-changed-socket.event.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
+
+import { BaseSocketEvent } from '@common/base/base-socket-event';
+
+class GameRoomMemberRoleChangedSocketEventBody {
+  @ApiProperty()
+  accountId: string;
+
+  @ApiProperty()
+  gameRoomId: string;
+
+  @ApiProperty({
+    title: 'GameRoomMemberRole',
+    enum: GameRoomMemberRole,
+    enumName: 'GameRoomMemberRole',
+  })
+  role: GameRoomMemberRole;
+
+  @ApiProperty()
+  nickname: string;
+}
+
+export class GameRoomMemberRoleChangedSocketEvent extends BaseSocketEvent<GameRoomMemberRoleChangedSocketEventBody> {
+  static readonly EVENT_NAME = 'game_room.member_role_changed';
+
+  @ApiProperty({ example: GameRoomMemberRoleChangedSocketEvent.EVENT_NAME })
+  readonly eventName: string = GameRoomMemberRoleChangedSocketEvent.EVENT_NAME;
+
+  @ApiProperty({ type: GameRoomMemberRoleChangedSocketEventBody })
+  body: GameRoomMemberRoleChangedSocketEventBody;
+}

--- a/src/modules/game-room/events/game-room-member-role-changed/game-room-member-role-changed.event.ts
+++ b/src/modules/game-room/events/game-room-member-role-changed/game-room-member-role-changed.event.ts
@@ -1,0 +1,15 @@
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
+
+import { DomainEvent } from '@common/base/base.domain-event';
+
+interface GameRoomMemberRoleChangedEventPayload {
+  gameRoomId: string;
+  accountId: string;
+  memberId: string;
+  role: GameRoomMemberRole;
+  nickname: string;
+}
+
+export class GameRoomMemberRoleChangedEvent extends DomainEvent<GameRoomMemberRoleChangedEventPayload> {
+  readonly aggregate = 'GameRoom';
+}

--- a/src/modules/game-room/events/game-room-member-role-changed/game-room-member-role-changed.handler.ts
+++ b/src/modules/game-room/events/game-room-member-role-changed/game-room-member-role-changed.handler.ts
@@ -1,0 +1,48 @@
+import { Inject } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { AsyncApi, AsyncApiPub } from 'nestjs-asyncapi';
+
+import { GameRoomMemberRoleChangedSocketEvent } from '@module/game-room/events/game-room-member-role-changed/game-room-member-role-changed-socket.event';
+import { GameRoomMemberRoleChangedEvent } from '@module/game-room/events/game-room-member-role-changed/game-room-member-role-changed.event';
+
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+  WS_NAMESPACE,
+} from '@core/socket/socket-event.emitter.interface';
+import { gameRoomKeyOf } from '@core/socket/socket-room.util';
+
+@AsyncApi()
+export class GameRoomMemberRoleChangedHandler {
+  constructor(
+    @Inject(SOCKET_EVENT_EMITTER)
+    private readonly socketEmitter: ISocketEventEmitter,
+  ) {}
+
+  @OnEvent(GameRoomMemberRoleChangedEvent.name)
+  async handle(event: GameRoomMemberRoleChangedEvent): Promise<void> {
+    this.publish(event);
+  }
+
+  @AsyncApiPub({
+    tags: [{ name: 'game_room' }],
+    description: '유저의 게임방 역할이 변경',
+    channel: GameRoomMemberRoleChangedSocketEvent.EVENT_NAME,
+    message: { payload: GameRoomMemberRoleChangedSocketEvent },
+  })
+  private publish(event: GameRoomMemberRoleChangedEvent): void {
+    const socketEvent = new GameRoomMemberRoleChangedSocketEvent({
+      accountId: event.eventPayload.accountId,
+      gameRoomId: event.eventPayload.gameRoomId,
+      role: event.eventPayload.role,
+      nickname: event.eventPayload.nickname,
+    });
+
+    this.socketEmitter.emitToRoom(
+      WS_NAMESPACE.ROOT,
+      gameRoomKeyOf(event.eventPayload.gameRoomId),
+      socketEvent,
+    );
+  }
+}

--- a/src/modules/game-room/events/game-room-member-role-changed/game-room-member-role-changed.module.ts
+++ b/src/modules/game-room/events/game-room-member-role-changed/game-room-member-role-changed.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { GameRoomMemberRoleChangedHandler } from '@module/game-room/events/game-room-member-role-changed/game-room-member-role-changed.handler';
+
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+
+@Module({
+  imports: [SocketEventEmitterModule],
+  providers: [GameRoomMemberRoleChangedHandler],
+})
+export class GameRoomMemberRoleChangedModule {}

--- a/src/modules/game-room/game-room.module.ts
+++ b/src/modules/game-room/game-room.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { GameRoomClosedModule } from '@module/game-room/events/game-room-closed/game-room-closed.module';
 import { GameRoomMemberJoinedModule } from '@module/game-room/events/game-room-member-joined/game-room-member-joined.module';
+import { GameRoomMemberLeftModule } from '@module/game-room/events/game-room-member-left/game-room-member-left.module';
+import { GameRoomMemberRoleChangedModule } from '@module/game-room/events/game-room-member-role-changed/game-room-member-role-changed.module';
 import { CreateGameRoomModule } from '@module/game-room/use-cases/create-game-room/create-game-room.module';
 import { JoinGameRoomModule } from '@module/game-room/use-cases/join-game-room/join-game-room.module';
+import { LeaveGameRoomModule } from '@module/game-room/use-cases/leave-game-room/leave-game-room.module';
 import { ListGameRoomMembersModule } from '@module/game-room/use-cases/list-game-room-members/list-game-room-members.module';
 import { ListGameRoomsModule } from '@module/game-room/use-cases/list-game-rooms/list-game-rooms.module';
 
@@ -10,10 +14,14 @@ import { ListGameRoomsModule } from '@module/game-room/use-cases/list-game-rooms
   imports: [
     CreateGameRoomModule,
     JoinGameRoomModule,
+    LeaveGameRoomModule,
     ListGameRoomMembersModule,
     ListGameRoomsModule,
 
+    GameRoomClosedModule,
     GameRoomMemberJoinedModule,
+    GameRoomMemberLeftModule,
+    GameRoomMemberRoleChangedModule,
   ],
 })
 export class GameRoomModule {}

--- a/src/modules/game-room/repositories/game-room/__spec__/game-room.repository.spec.ts
+++ b/src/modules/game-room/repositories/game-room/__spec__/game-room.repository.spec.ts
@@ -109,4 +109,28 @@ describe(GameRoomRepository, () => {
       });
     });
   });
+
+  describe(GameRoomRepository.prototype.decrementCurrentMembersCount, () => {
+    let gameRoom: GameRoom;
+
+    beforeEach(async () => {
+      gameRoom = await repository.insert(GameRoomFactory.build());
+    });
+
+    describe('현재 멤버 카운트를 감소시키면', () => {
+      it('현재 멤버 수가 1 감소해야한다.', async () => {
+        await expect(
+          repository.decrementCurrentMembersCount(gameRoom.id),
+        ).resolves.toBe(gameRoom.currentMembersCount - 1);
+      });
+    });
+
+    describe('게임방이 존재하지 않는 경우', () => {
+      it('레코드가 존재하지 않는다는 에러가 발생해야한다.', async () => {
+        await expect(
+          repository.decrementCurrentMembersCount(generateEntityId()),
+        ).rejects.toThrow(RecordNotFoundError);
+      });
+    });
+  });
 });

--- a/src/modules/game-room/repositories/game-room/game-room.repository.port.ts
+++ b/src/modules/game-room/repositories/game-room/game-room.repository.port.ts
@@ -17,4 +17,5 @@ export interface GameRoomRepositoryPort
   extends RepositoryPort<GameRoom, GameRoomFilter, GameRoomOrder> {
   findAll(options: { sort?: ISort[] }): Promise<GameRoom[]>;
   incrementCurrentMembersCount(gameRoomId: EntityId): Promise<number>;
+  decrementCurrentMembersCount(gameRoomId: EntityId): Promise<number>;
 }

--- a/src/modules/game-room/repositories/game-room/game-room.repository.ts
+++ b/src/modules/game-room/repositories/game-room/game-room.repository.ts
@@ -69,6 +69,31 @@ export class GameRoomRepository
     }
   }
 
+  async decrementCurrentMembersCount(gameRoomId: EntityId): Promise<number> {
+    try {
+      const updatedProject = await this.prismaService.gameRoom.update({
+        where: {
+          id: this.mapper.toPrimaryKey(gameRoomId),
+        },
+        data: {
+          currentMembersCount: {
+            decrement: 1,
+          },
+        },
+      });
+
+      return updatedProject.currentMembersCount;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2025') {
+          throw new RecordNotFoundError();
+        }
+      }
+
+      throw error;
+    }
+  }
+
   findAllCursorPaginated(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     params: ICursorPaginatedParams<GameRoomOrder, GameRoomFilter>,

--- a/src/modules/game-room/use-cases/leave-game-room/__spec__/leave-game-room-command.factory.ts
+++ b/src/modules/game-room/use-cases/leave-game-room/__spec__/leave-game-room-command.factory.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'rosie';
+
+import { LeaveGameRoomCommand } from '@module/game-room/use-cases/leave-game-room/leave-game-room.command';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+export const LeaveGameRoomCommandFactory = Factory.define<LeaveGameRoomCommand>(
+  LeaveGameRoomCommand.name,
+  LeaveGameRoomCommand,
+).attrs({
+  currentAccountId: () => generateEntityId(),
+  gameRoomId: () => generateEntityId(),
+});

--- a/src/modules/game-room/use-cases/leave-game-room/__spec__/leave-game-room.handler.spec.ts
+++ b/src/modules/game-room/use-cases/leave-game-room/__spec__/leave-game-room.handler.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { GameRoomMemberFactory } from '@module/game-room/entities/__spec__/game-room-member.factory';
+import { GameRoomFactory } from '@module/game-room/entities/__spec__/game-room.factory';
+import { GameRoomMember } from '@module/game-room/entities/game-room-member.entity';
+import { GameRoom } from '@module/game-room/entities/game-room.entity';
+import { GameRoomMemberNotFoundError } from '@module/game-room/errors/game-room-member-not-found.error';
+import { GameRoomNotFoundError } from '@module/game-room/errors/game-room-not-found.error';
+import { GameRoomMemberRepositoryModule } from '@module/game-room/repositories/game-room-member/game-room-member.repository.module';
+import {
+  GAME_ROOM_MEMBER_REPOSITORY,
+  GameRoomMemberRepositoryPort,
+} from '@module/game-room/repositories/game-room-member/game-room-member.repository.port';
+import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+import {
+  GAME_ROOM_REPOSITORY,
+  GameRoomRepositoryPort,
+} from '@module/game-room/repositories/game-room/game-room.repository.port';
+import { LeaveGameRoomCommandFactory } from '@module/game-room/use-cases/leave-game-room/__spec__/leave-game-room-command.factory';
+import { LeaveGameRoomCommand } from '@module/game-room/use-cases/leave-game-room/leave-game-room.command';
+import { LeaveGameRoomHandler } from '@module/game-room/use-cases/leave-game-room/leave-game-room.handler';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
+describe(LeaveGameRoomHandler.name, () => {
+  let handler: LeaveGameRoomHandler;
+
+  let gameRoomRepository: GameRoomRepositoryPort;
+  let gameRoomMemberRepository: GameRoomMemberRepositoryPort;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let eventStore: IEventStore;
+
+  let command: LeaveGameRoomCommand;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        GameRoomRepositoryModule,
+        GameRoomMemberRepositoryModule,
+        EventStoreModule,
+      ],
+      providers: [LeaveGameRoomHandler],
+    }).compile();
+
+    handler = module.get<LeaveGameRoomHandler>(LeaveGameRoomHandler);
+
+    gameRoomRepository =
+      module.get<GameRoomRepositoryPort>(GAME_ROOM_REPOSITORY);
+    gameRoomMemberRepository = module.get<GameRoomMemberRepositoryPort>(
+      GAME_ROOM_MEMBER_REPOSITORY,
+    );
+    eventStore = module.get<IEventStore>(EVENT_STORE);
+  });
+
+  beforeEach(() => {
+    command = LeaveGameRoomCommandFactory.build();
+  });
+
+  let gameRoom: GameRoom;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let hostMember: GameRoomMember;
+
+  beforeEach(async () => {
+    gameRoom = await gameRoomRepository.insert(
+      GameRoomFactory.build({
+        id: command.gameRoomId,
+        hostId: command.currentAccountId,
+      }),
+    );
+    hostMember = await gameRoomMemberRepository.insert(
+      GameRoomMemberFactory.build({
+        accountId: command.currentAccountId,
+        gameRoomId: command.gameRoomId,
+      }),
+    );
+  });
+
+  describe('호스트가 게임에서 나가는 경우', () => {
+    describe('남은 플레이어가 있다면', () => {
+      let nextHostMember: GameRoomMember;
+
+      beforeEach(async () => {
+        nextHostMember = await gameRoomMemberRepository.insert(
+          GameRoomMemberFactory.build({ gameRoomId: command.gameRoomId }),
+        );
+      });
+
+      it('남은 플레이어가 있다면 방장을 위임해야한다', async () => {
+        await expect(handler.execute(command)).resolves.toBeUndefined();
+
+        await expect(
+          gameRoomRepository.findOneById(gameRoom.id),
+        ).resolves.toEqual(
+          expect.objectContaining({
+            hostId: nextHostMember.accountId,
+          }),
+        );
+      });
+    });
+  });
+
+  describe('플레이어가 방에서 나가는 경우', () => {
+    let player: GameRoomMember;
+
+    beforeEach(async () => {
+      player = await gameRoomMemberRepository.insert(
+        GameRoomMemberFactory.build({ gameRoomId: command.gameRoomId }),
+      );
+    });
+
+    it('방에서 나가야 한다.', async () => {
+      await expect(
+        handler.execute({ ...command, currentAccountId: player.accountId }),
+      ).resolves.toBeUndefined();
+
+      await expect(
+        gameRoomMemberRepository.findByAccountIdInGameRoom(
+          player.accountId,
+          gameRoom.id,
+        ),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('마지막 플레어어가 나가는 경우', () => {
+    it('방이 삭제돼야한다.', async () => {
+      await expect(handler.execute(command)).resolves.toBeUndefined();
+
+      await expect(
+        gameRoomRepository.findOneById(command.gameRoomId),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('게임방이 존재하지 않는 경우', () => {
+    it('게임방이 존재하지 않는다는 에러가 발생해야한다.', async () => {
+      await expect(
+        handler.execute({ ...command, gameRoomId: generateEntityId() }),
+      ).rejects.toThrow(GameRoomNotFoundError);
+    });
+  });
+
+  describe('사용자가 게임방의 참가자가 아닌 경우', () => {
+    it('게임방의 구성원이 아니라는 에러가 발생해야한다.', async () => {
+      await expect(
+        handler.execute({ ...command, currentAccountId: generateEntityId() }),
+      ).rejects.toThrow(GameRoomMemberNotFoundError);
+    });
+  });
+});

--- a/src/modules/game-room/use-cases/leave-game-room/leave-game-room.command.ts
+++ b/src/modules/game-room/use-cases/leave-game-room/leave-game-room.command.ts
@@ -1,0 +1,16 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export interface ILeaveGameRoomCommandProps {
+  currentAccountId: string;
+  gameRoomId: string;
+}
+
+export class LeaveGameRoomCommand implements ICommand {
+  readonly currentAccountId: string;
+  readonly gameRoomId: string;
+
+  constructor(props: ILeaveGameRoomCommandProps) {
+    this.currentAccountId = props.currentAccountId;
+    this.gameRoomId = props.gameRoomId;
+  }
+}

--- a/src/modules/game-room/use-cases/leave-game-room/leave-game-room.controller.ts
+++ b/src/modules/game-room/use-cases/leave-game-room/leave-game-room.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Controller,
+  Delete,
+  HttpStatus,
+  Inject,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import {
+  ApiBearerAuth,
+  ApiNoContentResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '@module/auth/jwt/jwt-auth.guard';
+import { GameRoomAccessDeniedError } from '@module/game-room/errors/game-room-access-denied.error';
+import {
+  GAME_ROOM_ACCESS_CONTROL_SERVICE,
+  IGameRoomAccessControlService,
+} from '@module/game-room/services/game-room-access-control/game-room-access-control.service.interface';
+import { LeaveGameRoomCommand } from '@module/game-room/use-cases/leave-game-room/leave-game-room.command';
+
+import { BaseHttpException } from '@common/base/base-http-exception';
+import { RequestValidationError } from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import {
+  CurrentUser,
+  ICurrentUser,
+} from '@common/decorator/current-user.decorator';
+
+@ApiTags('room-member')
+@Controller()
+export class LeaveGameRoomController {
+  constructor(
+    private readonly commandBus: CommandBus,
+    @Inject(GAME_ROOM_ACCESS_CONTROL_SERVICE)
+    private readonly gameRoomAccessControlService: IGameRoomAccessControlService,
+  ) {}
+
+  @ApiOperation({ summary: '게임 방 퇴장' })
+  @ApiBearerAuth()
+  @ApiNoContentResponse()
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+  })
+  @UseGuards(JwtAuthGuard)
+  @Delete('/game-room/:gameRoomId/members/me')
+  async leaveGameRoom(
+    @CurrentUser() currentUser: ICurrentUser,
+    @Param('gameRoomId') gameRoomId: string,
+  ): Promise<void> {
+    try {
+      await this.gameRoomAccessControlService.allowMember({
+        accountId: currentUser.id,
+        gameRoomId,
+      });
+
+      const command = new LeaveGameRoomCommand({
+        currentAccountId: currentUser.id,
+        gameRoomId,
+      });
+
+      await this.commandBus.execute<LeaveGameRoomCommand, void>(command);
+    } catch (error) {
+      if (error instanceof GameRoomAccessDeniedError) {
+        throw new BaseHttpException(HttpStatus.FORBIDDEN, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/game-room/use-cases/leave-game-room/leave-game-room.handler.ts
+++ b/src/modules/game-room/use-cases/leave-game-room/leave-game-room.handler.ts
@@ -1,0 +1,79 @@
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
+import { GameRoomMemberNotFoundError } from '@module/game-room/errors/game-room-member-not-found.error';
+import { GameRoomNotFoundError } from '@module/game-room/errors/game-room-not-found.error';
+import {
+  GAME_ROOM_MEMBER_REPOSITORY,
+  GameRoomMemberRepositoryPort,
+} from '@module/game-room/repositories/game-room-member/game-room-member.repository.port';
+import {
+  GAME_ROOM_REPOSITORY,
+  GameRoomRepositoryPort,
+} from '@module/game-room/repositories/game-room/game-room.repository.port';
+import { LeaveGameRoomCommand } from '@module/game-room/use-cases/leave-game-room/leave-game-room.command';
+
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+
+@CommandHandler(LeaveGameRoomCommand)
+export class LeaveGameRoomHandler
+  implements ICommandHandler<LeaveGameRoomCommand, void>
+{
+  constructor(
+    @Inject(GAME_ROOM_REPOSITORY)
+    private readonly gameRoomRepository: GameRoomRepositoryPort,
+    @Inject(GAME_ROOM_MEMBER_REPOSITORY)
+    private readonly gameRoomMemberRepository: GameRoomMemberRepositoryPort,
+    @Inject(EVENT_STORE)
+    private readonly eventStore: IEventStore,
+  ) {}
+
+  async execute(command: LeaveGameRoomCommand): Promise<void> {
+    const [gameRoom, members] = await Promise.all([
+      this.gameRoomRepository.findOneById(command.gameRoomId),
+      this.gameRoomMemberRepository.findByGameRoomId(command.gameRoomId),
+    ]);
+
+    if (gameRoom === undefined) {
+      throw new GameRoomNotFoundError();
+    }
+
+    const targetMemberIdx = members.findIndex(
+      (member) => member.accountId === command.currentAccountId,
+    );
+    const member = members[targetMemberIdx];
+
+    if (member === undefined) {
+      throw new GameRoomMemberNotFoundError();
+    }
+
+    gameRoom.leave(member);
+    members.splice(targetMemberIdx, 1);
+
+    if (members.length === 0) {
+      gameRoom.close();
+
+      await this.gameRoomRepository.delete(gameRoom);
+    } else {
+      const hostMember = members.find(
+        (member) => member.accountId === gameRoom.hostId,
+      );
+
+      if (hostMember === undefined) {
+        const newHost = members[0];
+        gameRoom.changeMemberRole(newHost, GameRoomMemberRole.host);
+
+        await this.gameRoomRepository.update(gameRoom);
+        await this.gameRoomMemberRepository.update(newHost);
+      }
+
+      await this.gameRoomMemberRepository.delete(member);
+    }
+
+    await this.eventStore.storeAggregateEvents(gameRoom);
+  }
+}

--- a/src/modules/game-room/use-cases/leave-game-room/leave-game-room.module.ts
+++ b/src/modules/game-room/use-cases/leave-game-room/leave-game-room.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+
+import { GameRoomMemberRepositoryModule } from '@module/game-room/repositories/game-room-member/game-room-member.repository.module';
+import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+import { GameRoomAccessControlModule } from '@module/game-room/services/game-room-access-control/game-room-access-control.service.module';
+import { LeaveGameRoomController } from '@module/game-room/use-cases/leave-game-room/leave-game-room.controller';
+import { LeaveGameRoomHandler } from '@module/game-room/use-cases/leave-game-room/leave-game-room.handler';
+
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
+@Module({
+  imports: [
+    GameRoomAccessControlModule,
+    EventStoreModule,
+    GameRoomRepositoryModule,
+    GameRoomMemberRepositoryModule,
+  ],
+  controllers: [LeaveGameRoomController],
+  providers: [LeaveGameRoomHandler],
+})
+export class LeaveGameRoomModule {}


### PR DESCRIPTION
### Short description

유저의 게임 방 퇴장 rest API

### Proposed changes

- 게임 방 퇴장 rest API

1. 퇴장 후 게임방에 남은 구성원이 없다면 게임방 폐쇄
2. 호스트가 퇴장할 경우 다른 플레이어에게 호스트 위임

### How to test (Optional)

```bash
curl -X 'DELETE' \
  'http://localhost:3000/game-room/753155016168058811/members/me' \
  -H 'accept: */*' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NDczODA0NTc1MjM2Njk4NTQiLCJyb2xlIjoidXNlciIsImlhdCI6MTc1NzQwMDYwMiwiZXhwIjoxNzg4OTU4MjAyLCJpc3MiOiJxdWl6emVzX2dhbWVfaW9fYmFja2VuZCJ9.iYRJ-bIGYcXaeGCVjRHegW9U3zsP0N0upDDqDObjQ5k'
```

### Reference (Optional)

Closes #56
