### PR TITLE
게임 방 생성 이벤트 퍼블리시

### DIFF
--- a/socket-test.html
+++ b/socket-test.html
@@ -23,6 +23,10 @@
     </div>
 
     <div style="margin-bottom: 8px">
+      <button id="createBtn">Create Room (game_room.create)</button>
+    </div>
+
+    <div style="margin-bottom: 8px">
       <label
         >Room ID:
         <input
@@ -81,6 +85,9 @@
         );
 
         // --- Game Room Events ---
+        socket.on('game_room.created', (payload) => {
+          log('[game_room.created]', payload);
+        });
         socket.on('game_room.member_joined', (payload) => {
           log('[game_room.member_joined]', payload);
         });
@@ -102,6 +109,15 @@
         } else {
           log('Not connected.');
         }
+      });
+
+      // Create Room (game_room.create)
+      document.getElementById('createBtn').addEventListener('click', () => {
+        if (!socket || !socket.connected) return log('Socket is not connected');
+
+        socket.emit('game_room.create', {}, (ack) => {
+          log('[game_room.create ack]', ack);
+        });
       });
 
       // Join Room (game_room.subscribe)

--- a/src/modules/game-room/entities/game-room.entity.ts
+++ b/src/modules/game-room/entities/game-room.entity.ts
@@ -84,6 +84,7 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
         visibility: props.visibility,
         title: props.title,
         maxPlayers: props.maxMembersCount,
+        currentMembersCount: gameRoom.props.currentMembersCount,
       }),
     );
 

--- a/src/modules/game-room/events/game-room-created/__spec__/game-room-created.handler.spec.ts
+++ b/src/modules/game-room/events/game-room-created/__spec__/game-room-created.handler.spec.ts
@@ -1,0 +1,65 @@
+import { Test } from '@nestjs/testing';
+import { TestingModule } from '@nestjs/testing/testing-module';
+
+import {
+  GameRoomStatus,
+  GameRoomVisibility,
+} from '@module/game-room/entities/game-room.entity';
+import { GameRoomCreatedEvent } from '@module/game-room/events/game-room-created/game-room-created.event';
+import { GameRoomCreatedHandler } from '@module/game-room/events/game-room-created/game-room-created.handler';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+} from '@core/socket/socket-event.emitter.interface';
+
+describe(GameRoomCreatedHandler, () => {
+  let handler: GameRoomCreatedHandler;
+
+  let socketEmitter: ISocketEventEmitter;
+
+  let event: GameRoomCreatedEvent;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [SocketEventEmitterModule],
+      providers: [GameRoomCreatedHandler],
+    }).compile();
+
+    handler = module.get<GameRoomCreatedHandler>(GameRoomCreatedHandler);
+    socketEmitter = module.get<ISocketEventEmitter>(SOCKET_EVENT_EMITTER);
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(socketEmitter, 'emitToNamespace')
+      .mockResolvedValue(undefined as never);
+  });
+
+  beforeEach(async () => {
+    const gameRoomId = generateEntityId();
+    event = new GameRoomCreatedEvent(gameRoomId, {
+      hostId: generateEntityId(),
+      status: GameRoomStatus.waiting,
+      visibility: GameRoomVisibility.public,
+      title: 'title',
+      maxPlayers: 8,
+      currentMembersCount: 0,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('게임방이 생성되면', () => {
+    it('소켓 이벤트를 발생시켜야한다.', async () => {
+      await expect(handler.handle(event)).resolves.toBeUndefined();
+
+      expect(socketEmitter.emitToNamespace).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/game-room/events/game-room-created/game-room-created-socket.event.ts
+++ b/src/modules/game-room/events/game-room-created/game-room-created-socket.event.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import {
+  GameRoomStatus,
+  GameRoomVisibility,
+} from '@module/game-room/entities/game-room.entity';
+
+import { BaseSocketEvent } from '@common/base/base-socket-event';
+
+class GameRoomCreatedSocketEventBody {
+  @ApiProperty()
+  gameRoomId: string;
+
+  @ApiProperty({
+    title: 'GameRoomStatus',
+    enum: GameRoomStatus,
+    enumName: 'GameRoomStatus',
+  })
+  status: GameRoomStatus;
+
+  @ApiProperty({
+    title: 'GameRoomVisibility',
+    enum: GameRoomVisibility,
+    enumName: 'GameRoomVisibility',
+  })
+  visibility: GameRoomVisibility;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  maxPlayers: number;
+
+  @ApiProperty()
+  currentMembersCount: number;
+}
+
+export class GameRoomCreatedSocketEvent extends BaseSocketEvent<GameRoomCreatedSocketEventBody> {
+  static readonly EVENT_NAME = 'game_room.created';
+
+  @ApiProperty({ example: GameRoomCreatedSocketEvent.EVENT_NAME })
+  readonly eventName: string = GameRoomCreatedSocketEvent.EVENT_NAME;
+
+  @ApiProperty({ type: GameRoomCreatedSocketEventBody })
+  body: GameRoomCreatedSocketEventBody;
+}

--- a/src/modules/game-room/events/game-room-created/game-room-created.event.ts
+++ b/src/modules/game-room/events/game-room-created/game-room-created.event.ts
@@ -11,6 +11,7 @@ interface GameRoomCreatedEventPayload {
   visibility: GameRoomVisibility;
   title: string;
   maxPlayers: number;
+  currentMembersCount: number;
 }
 
 export class GameRoomCreatedEvent extends DomainEvent<GameRoomCreatedEventPayload> {

--- a/src/modules/game-room/events/game-room-created/game-room-created.handler.ts
+++ b/src/modules/game-room/events/game-room-created/game-room-created.handler.ts
@@ -1,0 +1,45 @@
+import { Inject } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { AsyncApi, AsyncApiPub } from 'nestjs-asyncapi';
+
+import { GameRoomCreatedSocketEvent } from '@module/game-room/events/game-room-created/game-room-created-socket.event';
+import { GameRoomCreatedEvent } from '@module/game-room/events/game-room-created/game-room-created.event';
+
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+  WS_NAMESPACE,
+} from '@core/socket/socket-event.emitter.interface';
+
+@AsyncApi()
+export class GameRoomCreatedHandler {
+  constructor(
+    @Inject(SOCKET_EVENT_EMITTER)
+    private readonly socketEmitter: ISocketEventEmitter,
+  ) {}
+
+  @OnEvent(GameRoomCreatedEvent.name)
+  async handle(event: GameRoomCreatedEvent): Promise<void> {
+    this.publish(event);
+  }
+
+  @AsyncApiPub({
+    tags: [{ name: 'game_room' }],
+    description: '게임방이 생성됨',
+    channel: GameRoomCreatedSocketEvent.EVENT_NAME,
+    message: { payload: GameRoomCreatedSocketEvent },
+  })
+  private publish(event: GameRoomCreatedEvent): void {
+    const socketEvent = new GameRoomCreatedSocketEvent({
+      gameRoomId: event.aggregateId,
+      status: event.eventPayload.status,
+      visibility: event.eventPayload.visibility,
+      title: event.eventPayload.title,
+      maxPlayers: event.eventPayload.maxPlayers,
+      currentMembersCount: event.eventPayload.currentMembersCount,
+    });
+
+    this.socketEmitter.emitToNamespace(WS_NAMESPACE.ROOT, socketEvent);
+  }
+}

--- a/src/modules/game-room/events/game-room-created/game-room-created.module.ts
+++ b/src/modules/game-room/events/game-room-created/game-room-created.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { GameRoomCreatedHandler } from '@module/game-room/events/game-room-created/game-room-created.handler';
+
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+
+@Module({
+  imports: [SocketEventEmitterModule],
+  providers: [GameRoomCreatedHandler],
+})
+export class GameRoomCreatedModule {}

--- a/src/modules/game-room/game-room.module.ts
+++ b/src/modules/game-room/game-room.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { GameRoomClosedModule } from '@module/game-room/events/game-room-closed/game-room-closed.module';
+import { GameRoomCreatedModule } from '@module/game-room/events/game-room-created/game-room-created.module';
 import { GameRoomMemberJoinedModule } from '@module/game-room/events/game-room-member-joined/game-room-member-joined.module';
 import { GameRoomMemberLeftModule } from '@module/game-room/events/game-room-member-left/game-room-member-left.module';
 import { GameRoomMemberRoleChangedModule } from '@module/game-room/events/game-room-member-role-changed/game-room-member-role-changed.module';
@@ -19,6 +20,7 @@ import { ListGameRoomsModule } from '@module/game-room/use-cases/list-game-rooms
     ListGameRoomsModule,
 
     GameRoomClosedModule,
+    GameRoomCreatedModule,
     GameRoomMemberJoinedModule,
     GameRoomMemberLeftModule,
     GameRoomMemberRoleChangedModule,


### PR DESCRIPTION
### Short description

로비에 있는 사용자에게 새로운 게임방이 생성됨을 알려주기 위해 게임방 생성 이벤트를 퍼블리시한다

### Proposed changes

- 게임 방 생성 시 게임 방 생성 이벤트 퍼블리시

### How to test (Optional)

```bash
curl -X 'POST' \
  'http://localhost:3000/game-rooms' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NDczODA0NTc1MjM2Njk4NTQiLCJyb2xlIjoidXNlciIsImlhdCI6MTc1NzQwMDYwMiwiZXhwIjoxNzg4OTU4MjAyLCJpc3MiOiJxdWl6emVzX2dhbWVfaW9fYmFja2VuZCJ9.iYRJ-bIGYcXaeGCVjRHegW9U3zsP0N0upDDqDObjQ5k' \
  -H 'Content-Type: application/json' \
  -d '{
  "title": "My Awesome Game Room"
}'
```

### Reference (Optional)

Closes #57 
