### PR TITLE
게임 시작 REST API 

### DIFF
--- a/prisma/migrations/20250918082708_game_room_status_ready_to_starting/migration.sql
+++ b/prisma/migrations/20250918082708_game_room_status_ready_to_starting/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [ready] on the enum `GameRoomStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "GameRoomStatus_new" AS ENUM ('waiting', 'starting', 'inProgress', 'finished', 'paused');
+ALTER TABLE "game_room" ALTER COLUMN "status" TYPE "GameRoomStatus_new" USING ("status"::text::"GameRoomStatus_new");
+ALTER TYPE "GameRoomStatus" RENAME TO "GameRoomStatus_old";
+ALTER TYPE "GameRoomStatus_new" RENAME TO "GameRoomStatus";
+DROP TYPE "GameRoomStatus_old";
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,7 @@ model AccountEventStore {
 
 enum GameRoomStatus {
   waiting
-  ready
+  starting
   inProgress
   finished
   paused

--- a/src/modules/game-room/entities/__spec__/game-room.entity.spec.ts
+++ b/src/modules/game-room/entities/__spec__/game-room.entity.spec.ts
@@ -58,6 +58,29 @@ describe(GameRoom, () => {
     });
   });
 
+  describe(GameRoom.prototype.start, () => {
+    describe('게임방이 대기 상태라면', () => {
+      beforeEach(() => {
+        gameRoom.props.status = GameRoomStatus.waiting;
+      });
+
+      it('시작중으로 상태를 변경해야한다.', () => {
+        gameRoom.start();
+        expect(gameRoom.status).toBe(GameRoomStatus.starting);
+      });
+    });
+
+    describe('게임방이 대기 상태가 아니라면', () => {
+      beforeEach(() => {
+        gameRoom.props.status = GameRoomStatus.paused;
+      });
+
+      it('게임 시작은 대기 상태에서만 가능하다는 에러가 발생해야한다.', () => {
+        expect(() => gameRoom.start()).toThrow(GameRoomValidationError);
+      });
+    });
+  });
+
   describe(GameRoom.prototype.joinMember, () => {
     let member: GameRoomMember;
 

--- a/src/modules/game-room/entities/game-room.entity.ts
+++ b/src/modules/game-room/entities/game-room.entity.ts
@@ -10,6 +10,7 @@ import { GameRoomCreatedEvent } from '@module/game-room/events/game-room-created
 import { GameRoomMemberJoinedEvent } from '@module/game-room/events/game-room-member-joined/game-room-member-joined.event';
 import { GameRoomMemberLeftEvent } from '@module/game-room/events/game-room-member-left/game-room-member-left.event';
 import { GameRoomMemberRoleChangedEvent } from '@module/game-room/events/game-room-member-role-changed/game-room-member-role-changed.event';
+import { GameRoomStartingEvent } from '@module/game-room/events/game-room-starting/game-room-starting.event';
 
 import {
   AggregateRoot,
@@ -31,9 +32,6 @@ export enum GameRoomVisibility {
   hidden = 'hidden',
 }
 
-/**
- * @todo currentMembersCount를 필드로 정의하지 않고 구성원을 세게끔 변경
- */
 export interface GameRoomProps {
   hostAccountId: string;
   status: GameRoomStatus;
@@ -132,6 +130,23 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
   }
   set members(value: GameRoomMember[]) {
     this.props.members = value;
+  }
+
+  start() {
+    if (this.props.status !== GameRoomStatus.waiting) {
+      throw new GameRoomValidationError(
+        'Game can only be started from the waiting state.',
+      );
+    }
+
+    this.props.status = GameRoomStatus.starting;
+
+    this.apply(
+      new GameRoomStartingEvent(this.id, {
+        gameRoomId: this.id,
+        status: this.props.status,
+      }),
+    );
   }
 
   close() {

--- a/src/modules/game-room/entities/game-room.entity.ts
+++ b/src/modules/game-room/entities/game-room.entity.ts
@@ -19,7 +19,7 @@ import {
 
 export enum GameRoomStatus {
   waiting = 'waiting',
-  ready = 'ready',
+  starting = 'starting',
   inProgress = 'inProgress',
   finished = 'finished',
   paused = 'paused',

--- a/src/modules/game-room/events/game-room-starting/__spec__/game-room-starting.handler.spec.ts
+++ b/src/modules/game-room/events/game-room-starting/__spec__/game-room-starting.handler.spec.ts
@@ -1,0 +1,78 @@
+import { Test } from '@nestjs/testing';
+import { TestingModule } from '@nestjs/testing/testing-module';
+
+import { GameRoomFactory } from '@module/game-room/entities/__spec__/game-room.factory';
+import {
+  GameRoom,
+  GameRoomStatus,
+} from '@module/game-room/entities/game-room.entity';
+import { GameRoomStartingEvent } from '@module/game-room/events/game-room-starting/game-room-starting.event';
+import { GameRoomStartingHandler } from '@module/game-room/events/game-room-starting/game-room-starting.handler';
+import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+import {
+  GAME_ROOM_REPOSITORY,
+  GameRoomRepositoryPort,
+} from '@module/game-room/repositories/game-room/game-room.repository.port';
+
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+} from '@core/socket/socket-event.emitter.interface';
+
+describe(GameRoomStartingHandler, () => {
+  let handler: GameRoomStartingHandler;
+
+  let gameRoomRepository: GameRoomRepositoryPort;
+
+  let socketEmitter: ISocketEventEmitter;
+
+  let event: GameRoomStartingEvent;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [GameRoomRepositoryModule, SocketEventEmitterModule],
+      providers: [GameRoomStartingHandler],
+    }).compile();
+
+    handler = module.get<GameRoomStartingHandler>(GameRoomStartingHandler);
+    gameRoomRepository =
+      module.get<GameRoomRepositoryPort>(GAME_ROOM_REPOSITORY);
+    socketEmitter = module.get<ISocketEventEmitter>(SOCKET_EVENT_EMITTER);
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(socketEmitter, 'emitToRoom')
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(socketEmitter, 'emitToNamespace')
+      .mockResolvedValue(undefined as never);
+  });
+
+  let existingGameRoom: GameRoom;
+
+  beforeEach(async () => {
+    existingGameRoom = await gameRoomRepository.insert(
+      GameRoomFactory.build({}),
+    );
+
+    event = new GameRoomStartingEvent(existingGameRoom.id, {
+      gameRoomId: existingGameRoom.id,
+      status: GameRoomStatus.starting,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('게임방이 폐쇄되면', () => {
+    it('소켓 이벤트를 발생시켜야한다.', async () => {
+      await expect(handler.handle(event)).resolves.toBeUndefined();
+
+      expect(socketEmitter.emitToRoom).toHaveBeenCalled();
+      expect(socketEmitter.emitToNamespace).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/game-room/events/game-room-starting/game-room-starting.event.ts
+++ b/src/modules/game-room/events/game-room-starting/game-room-starting.event.ts
@@ -1,0 +1,12 @@
+import { GameRoomStatus } from '@module/game-room/entities/game-room.entity';
+
+import { DomainEvent } from '@common/base/base.domain-event';
+
+interface GameRoomStartingEventPayload {
+  gameRoomId: string;
+  status: GameRoomStatus;
+}
+
+export class GameRoomStartingEvent extends DomainEvent<GameRoomStartingEventPayload> {
+  readonly aggregate = 'GameRoom';
+}

--- a/src/modules/game-room/events/game-room-starting/game-room-starting.handler.ts
+++ b/src/modules/game-room/events/game-room-starting/game-room-starting.handler.ts
@@ -1,0 +1,78 @@
+import { Inject } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { AsyncApi, AsyncApiPub } from 'nestjs-asyncapi';
+
+import { GameRoomDtoAssembler } from '@module/game-room/assemblers/game-room-dto.assembler';
+import { GameRoom } from '@module/game-room/entities/game-room.entity';
+import { GameRoomStartingEvent } from '@module/game-room/events/game-room-starting/game-room-starting.event';
+import {
+  GAME_ROOM_REPOSITORY,
+  GameRoomRepositoryPort,
+} from '@module/game-room/repositories/game-room/game-room.repository.port';
+import {
+  GameRoomChangedSocketEvent,
+  GameRoomChangedSocketEventAction,
+  LobbyGameRoomChangedSocketEvent,
+} from '@module/game-room/socket-events/game-room-changed.socket-event';
+
+import {
+  ISocketEventEmitter,
+  SOCKET_EVENT_EMITTER,
+  WS_NAMESPACE,
+} from '@core/socket/socket-event.emitter.interface';
+import { gameRoomKeyOf } from '@core/socket/socket-room.util';
+
+@AsyncApi()
+export class GameRoomStartingHandler {
+  constructor(
+    @Inject(GAME_ROOM_REPOSITORY)
+    private readonly gameRoomRepository: GameRoomRepositoryPort,
+    @Inject(SOCKET_EVENT_EMITTER)
+    private readonly socketEmitter: ISocketEventEmitter,
+  ) {}
+
+  @OnEvent(GameRoomStartingEvent.name)
+  async handle(event: GameRoomStartingEvent): Promise<void> {
+    const gameRoom = await this.gameRoomRepository.findOneById(
+      event.aggregateId,
+    );
+
+    this.publishGameRoomEvent(gameRoom as GameRoom);
+    this.publishLobbyEvent(gameRoom as GameRoom);
+  }
+
+  @AsyncApiPub({
+    tags: [{ name: 'game_room' }],
+    description: '게임 시작 처리',
+    channel: GameRoomChangedSocketEvent.EVENT_NAME,
+    message: { payload: GameRoomChangedSocketEvent },
+  })
+  private publishGameRoomEvent(gameRoom: GameRoom): void {
+    const socketEvent = new GameRoomChangedSocketEvent(
+      GameRoomChangedSocketEventAction.game_starting,
+      GameRoomDtoAssembler.convertToSocketEventDto(gameRoom),
+    );
+
+    this.socketEmitter.emitToRoom(
+      WS_NAMESPACE.ROOT,
+      gameRoomKeyOf(gameRoom.id),
+      socketEvent,
+    );
+  }
+
+  @AsyncApiPub({
+    tags: [{ name: 'lobby' }],
+    description: '게임 시작 처리',
+    channel: LobbyGameRoomChangedSocketEvent.EVENT_NAME,
+    message: { payload: LobbyGameRoomChangedSocketEvent },
+  })
+  private publishLobbyEvent(gameRoom: GameRoom): void {
+    const socketEvent = new LobbyGameRoomChangedSocketEvent(
+      GameRoomChangedSocketEventAction.game_starting,
+      GameRoomDtoAssembler.convertToSocketEventDto(gameRoom),
+    );
+
+    this.socketEmitter.emitToNamespace(WS_NAMESPACE.ROOT, socketEvent);
+  }
+}

--- a/src/modules/game-room/events/game-room-starting/game-room-starting.module.ts
+++ b/src/modules/game-room/events/game-room-starting/game-room-starting.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { GameRoomClosedHandler } from '@module/game-room/events/game-room-closed/game-room-closed.handler';
+import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+
+import { SocketEventEmitterModule } from '@core/socket/socket-event-emitter.module';
+
+@Module({
+  imports: [GameRoomRepositoryModule, SocketEventEmitterModule],
+  providers: [GameRoomClosedHandler],
+})
+export class GameRoomStartingModule {}

--- a/src/modules/game-room/game-room.module.ts
+++ b/src/modules/game-room/game-room.module.ts
@@ -11,6 +11,7 @@ import { JoinGameRoomModule } from '@module/game-room/use-cases/join-game-room/j
 import { LeaveGameRoomModule } from '@module/game-room/use-cases/leave-game-room/leave-game-room.module';
 import { ListGameRoomMembersModule } from '@module/game-room/use-cases/list-game-room-members/list-game-room-members.module';
 import { ListGameRoomsModule } from '@module/game-room/use-cases/list-game-rooms/list-game-rooms.module';
+import { StartGameModule } from '@module/game-room/use-cases/start-game/start-game.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { ListGameRoomsModule } from '@module/game-room/use-cases/list-game-rooms
     LeaveGameRoomModule,
     ListGameRoomMembersModule,
     ListGameRoomsModule,
+    StartGameModule,
 
     GameRoomClosedModule,
     GameRoomCreatedModule,

--- a/src/modules/game-room/services/game-room-access-control/__spec__/game-room-access-control.service.spec.ts
+++ b/src/modules/game-room/services/game-room-access-control/__spec__/game-room-access-control.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { GameRoomMemberFactory } from '@module/game-room/entities/__spec__/game-room-member.factory';
 import { GameRoomFactory } from '@module/game-room/entities/__spec__/game-room.factory';
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
 import { GameRoomAccessDeniedError } from '@module/game-room/errors/game-room-access-denied.error';
 import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
 import {
@@ -10,6 +11,7 @@ import {
 } from '@module/game-room/repositories/game-room/game-room.repository.port';
 import { GameRoomAccessControlService } from '@module/game-room/services/game-room-access-control/game-room-access-control.service';
 import {
+  AllowHostProps,
   AllowMemberProps,
   GAME_ROOM_ACCESS_CONTROL_SERVICE,
   IGameRoomAccessControlService,
@@ -85,6 +87,79 @@ describe(GameRoomAccessControlService, () => {
 
       it('게임방의 접근 권한이 없다는 에러가 발생해야한다.', async () => {
         await expect(service.allowMember(props)).rejects.toThrow(
+          GameRoomAccessDeniedError,
+        );
+      });
+    });
+  });
+
+  describe(GameRoomAccessControlService.prototype.allowHost, () => {
+    let props: AllowHostProps;
+
+    beforeEach(() => {
+      props = {
+        accountId: generateEntityId(),
+        gameRoomId: generateEntityId(),
+      };
+    });
+
+    describe('게임방의 호스트인 경우', () => {
+      beforeEach(async () => {
+        await gameRoomRepository.insert(
+          GameRoomFactory.build({
+            id: props.gameRoomId,
+            members: [
+              GameRoomMemberFactory.build({
+                accountId: props.accountId,
+                role: GameRoomMemberRole.host,
+              }),
+            ],
+          }),
+        );
+      });
+
+      it('에러가 발생하지 않아야한다.', async () => {
+        await expect(service.allowHost(props)).resolves.toBeUndefined();
+      });
+    });
+
+    describe('게임방이 존재하지 않는 경우', () => {
+      it('게임방의 접근 권한이 없다는 에러가 발생해야한다.', async () => {
+        await expect(service.allowHost(props)).rejects.toThrow(
+          GameRoomAccessDeniedError,
+        );
+      });
+    });
+
+    describe('게임방의 구성원이 아닌 경우', () => {
+      beforeEach(async () => {
+        await gameRoomRepository.insert(GameRoomFactory.build({}));
+      });
+
+      it('게임방의 접근 권한이 없다는 에러가 발생해야한다.', async () => {
+        await expect(service.allowHost(props)).rejects.toThrow(
+          GameRoomAccessDeniedError,
+        );
+      });
+    });
+
+    describe('게임방의 일반 구성원인 경우', () => {
+      beforeEach(async () => {
+        await gameRoomRepository.insert(
+          GameRoomFactory.build({
+            id: props.gameRoomId,
+            members: [
+              GameRoomMemberFactory.build({
+                accountId: props.accountId,
+                role: GameRoomMemberRole.player,
+              }),
+            ],
+          }),
+        );
+      });
+
+      it('호스트만 접근할 수 있다는 에러가 발생해야한다.', async () => {
+        await expect(service.allowHost(props)).rejects.toThrow(
           GameRoomAccessDeniedError,
         );
       });

--- a/src/modules/game-room/services/game-room-access-control/game-room-access-control.service.interface.ts
+++ b/src/modules/game-room/services/game-room-access-control/game-room-access-control.service.interface.ts
@@ -7,6 +7,12 @@ export interface AllowMemberProps {
   gameRoomId: string;
 }
 
+export interface AllowHostProps {
+  accountId: string;
+  gameRoomId: string;
+}
+
 export interface IGameRoomAccessControlService {
   allowMember(props: AllowMemberProps): Promise<void>;
+  allowHost(props: AllowHostProps): Promise<void>;
 }

--- a/src/modules/game-room/services/game-room-access-control/game-room-access-control.service.ts
+++ b/src/modules/game-room/services/game-room-access-control/game-room-access-control.service.ts
@@ -1,11 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common';
 
+import { GameRoomMemberRole } from '@module/game-room/entities/game-room-member.entity';
 import { GameRoomAccessDeniedError } from '@module/game-room/errors/game-room-access-denied.error';
 import {
   GAME_ROOM_REPOSITORY,
   GameRoomRepositoryPort,
 } from '@module/game-room/repositories/game-room/game-room.repository.port';
 import {
+  AllowHostProps,
   AllowMemberProps,
   IGameRoomAccessControlService,
 } from '@module/game-room/services/game-room-access-control/game-room-access-control.service.interface';
@@ -35,6 +37,32 @@ export class GameRoomAccessControlService
     if (gameRoomMember === undefined) {
       throw new GameRoomAccessDeniedError(
         'Only members of the game room can access it',
+      );
+    }
+  }
+
+  async allowHost(props: AllowHostProps): Promise<void> {
+    const gameRoom = await this.gameRoomRepository.findOneById(
+      props.gameRoomId,
+    );
+
+    if (gameRoom === undefined) {
+      throw new GameRoomAccessDeniedError('Game room not found');
+    }
+
+    const member = gameRoom.members.find(
+      (member) => member.accountId === props.accountId,
+    );
+
+    if (member === undefined) {
+      throw new GameRoomAccessDeniedError(
+        'Only members of the game room can access it',
+      );
+    }
+
+    if (member.role !== GameRoomMemberRole.host) {
+      throw new GameRoomAccessDeniedError(
+        'Only host of the game room can access it',
       );
     }
   }

--- a/src/modules/game-room/socket-events/game-room-changed.socket-event.ts
+++ b/src/modules/game-room/socket-events/game-room-changed.socket-event.ts
@@ -8,6 +8,7 @@ export enum GameRoomChangedSocketEventAction {
   member_joined = 'member_joined',
   member_left = 'member_left',
   member_role_changed = 'member_role_changed',
+  game_starting = 'game_starting',
 }
 
 export class GameRoomChangedSocketEvent extends BaseSocketEvent<GameRoomSocketEventDto> {
@@ -22,6 +23,23 @@ export class GameRoomChangedSocketEvent extends BaseSocketEvent<GameRoomSocketEv
 
   @ApiProperty({ example: GameRoomChangedSocketEvent.EVENT_NAME })
   readonly eventName: string = GameRoomChangedSocketEvent.EVENT_NAME;
+
+  @ApiProperty({ type: GameRoomSocketEventDto })
+  body: GameRoomSocketEventDto;
+}
+
+export class LobbyGameRoomChangedSocketEvent extends BaseSocketEvent<GameRoomSocketEventDto> {
+  static readonly EVENT_NAME = 'lobby.game_room.changed';
+
+  @ApiProperty({
+    title: 'GameRoomChangedSocketEventAction',
+    enum: GameRoomChangedSocketEventAction,
+    enumName: 'GameRoomChangedSocketEventAction',
+  })
+  action: GameRoomChangedSocketEventAction;
+
+  @ApiProperty({ example: LobbyGameRoomChangedSocketEvent.EVENT_NAME })
+  readonly eventName: string = LobbyGameRoomChangedSocketEvent.EVENT_NAME;
 
   @ApiProperty({ type: GameRoomSocketEventDto })
   body: GameRoomSocketEventDto;

--- a/src/modules/game-room/use-cases/start-game/__spec__/start-game-command.factory.ts
+++ b/src/modules/game-room/use-cases/start-game/__spec__/start-game-command.factory.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'rosie';
+
+import { StartGameCommand } from '@module/game-room/use-cases/start-game/start-game.command';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+export const StartGameCommandFactory = Factory.define<StartGameCommand>(
+  StartGameCommand.name,
+  StartGameCommand,
+).attrs({
+  gameRoomId: () => generateEntityId(),
+});

--- a/src/modules/game-room/use-cases/start-game/__spec__/start-game.handler.spec.ts
+++ b/src/modules/game-room/use-cases/start-game/__spec__/start-game.handler.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { GameRoomFactory } from '@module/game-room/entities/__spec__/game-room.factory';
+import {
+  GameRoom,
+  GameRoomStatus,
+} from '@module/game-room/entities/game-room.entity';
+import { GameRoomNotFoundError } from '@module/game-room/errors/game-room-not-found.error';
+import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+import {
+  GAME_ROOM_REPOSITORY,
+  GameRoomRepositoryPort,
+} from '@module/game-room/repositories/game-room/game-room.repository.port';
+import { StartGameCommandFactory } from '@module/game-room/use-cases/start-game/__spec__/start-game-command.factory';
+import { StartGameCommand } from '@module/game-room/use-cases/start-game/start-game.command';
+import { StartGameHandler } from '@module/game-room/use-cases/start-game/start-game.handler';
+
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
+describe(StartGameHandler.name, () => {
+  let handler: StartGameHandler;
+
+  let gameRoomRepository: GameRoomRepositoryPort;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let eventStore: IEventStore;
+
+  let command: StartGameCommand;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [GameRoomRepositoryModule, EventStoreModule],
+      providers: [StartGameHandler],
+    }).compile();
+
+    handler = module.get<StartGameHandler>(StartGameHandler);
+
+    gameRoomRepository =
+      module.get<GameRoomRepositoryPort>(GAME_ROOM_REPOSITORY);
+    eventStore = module.get<IEventStore>(EVENT_STORE);
+  });
+
+  beforeEach(() => {
+    command = StartGameCommandFactory.build();
+  });
+
+  describe('대기 상태의 게임방이 존재하는 경우', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let waitingStatusGameRoom: GameRoom;
+
+    beforeEach(async () => {
+      waitingStatusGameRoom = await gameRoomRepository.insert(
+        GameRoomFactory.build({
+          id: command.gameRoomId,
+          status: GameRoomStatus.waiting,
+        }),
+      );
+    });
+
+    it('게임이 시작되어야한다.', async () => {
+      await expect(handler.execute(command)).resolves.toEqual(
+        expect.objectContaining({
+          status: GameRoomStatus.starting,
+        }),
+      );
+    });
+  });
+
+  describe('게임방이 존재하지 않는 경우', () => {
+    it('게임방이 존재하지 않는다는 에러가 발생해야한다.', async () => {
+      expect(handler.execute(command)).rejects.toThrow(GameRoomNotFoundError);
+    });
+  });
+});

--- a/src/modules/game-room/use-cases/start-game/start-game.command.ts
+++ b/src/modules/game-room/use-cases/start-game/start-game.command.ts
@@ -1,0 +1,13 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export interface IStartGameCommandProps {
+  gameRoomId: string;
+}
+
+export class StartGameCommand implements ICommand {
+  readonly gameRoomId: string;
+
+  constructor(props: IStartGameCommandProps) {
+    this.gameRoomId = props.gameRoomId;
+  }
+}

--- a/src/modules/game-room/use-cases/start-game/start-game.controller.ts
+++ b/src/modules/game-room/use-cases/start-game/start-game.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Controller,
+  HttpStatus,
+  Inject,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '@module/auth/jwt/jwt-auth.guard';
+import { GameRoomDtoAssembler } from '@module/game-room/assemblers/game-room-dto.assembler';
+import { GameRoomDto } from '@module/game-room/dto/game-room.dto';
+import { GameRoom } from '@module/game-room/entities/game-room.entity';
+import { GameRoomAccessDeniedError } from '@module/game-room/errors/game-room-access-denied.error';
+import { GameRoomNotFoundError } from '@module/game-room/errors/game-room-not-found.error';
+import { GameRoomValidationError } from '@module/game-room/errors/game-room-validation.error';
+import {
+  GAME_ROOM_ACCESS_CONTROL_SERVICE,
+  IGameRoomAccessControlService,
+} from '@module/game-room/services/game-room-access-control/game-room-access-control.service.interface';
+import { StartGameCommand } from '@module/game-room/use-cases/start-game/start-game.command';
+
+import { BaseHttpException } from '@common/base/base-http-exception';
+import { RequestValidationError } from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import {
+  CurrentUser,
+  ICurrentUser,
+} from '@common/decorator/current-user.decorator';
+
+@ApiTags('game-room')
+@Controller()
+export class StartGameController {
+  constructor(
+    private readonly commandBus: CommandBus,
+    @Inject(GAME_ROOM_ACCESS_CONTROL_SERVICE)
+    private readonly gameRoomAccessControlService: IGameRoomAccessControlService,
+  ) {}
+
+  @ApiOperation({ summary: '게임 시작 요청' })
+  @ApiOkResponse({ type: GameRoomDto })
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError, GameRoomValidationError],
+    [HttpStatus.FORBIDDEN]: [GameRoomAccessDeniedError],
+    [HttpStatus.NOT_FOUND]: [GameRoomNotFoundError],
+  })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Post('/game-room/:gameRoomId/start')
+  async startGame(
+    @CurrentUser() currentUser: ICurrentUser,
+    @Param('gameRoomId') gameRoomId: string,
+  ): Promise<GameRoomDto> {
+    try {
+      await this.gameRoomAccessControlService.allowHost({
+        accountId: currentUser.id,
+        gameRoomId,
+      });
+
+      const command = new StartGameCommand({ gameRoomId });
+
+      const gameRoom = await this.commandBus.execute<
+        StartGameCommand,
+        GameRoom
+      >(command);
+
+      return GameRoomDtoAssembler.convertToDto(gameRoom);
+    } catch (error) {
+      if (error instanceof GameRoomAccessDeniedError) {
+        throw new BaseHttpException(HttpStatus.FORBIDDEN, error);
+      }
+      if (error instanceof GameRoomNotFoundError) {
+        throw new BaseHttpException(HttpStatus.NOT_FOUND, error);
+      }
+      if (error instanceof GameRoomValidationError) {
+        throw new BaseHttpException(HttpStatus.BAD_REQUEST, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/game-room/use-cases/start-game/start-game.handler.ts
+++ b/src/modules/game-room/use-cases/start-game/start-game.handler.ts
@@ -1,0 +1,45 @@
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { GameRoom } from '@module/game-room/entities/game-room.entity';
+import { GameRoomNotFoundError } from '@module/game-room/errors/game-room-not-found.error';
+import {
+  GAME_ROOM_REPOSITORY,
+  GameRoomRepositoryPort,
+} from '@module/game-room/repositories/game-room/game-room.repository.port';
+import { StartGameCommand } from '@module/game-room/use-cases/start-game/start-game.command';
+
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+
+@CommandHandler(StartGameCommand)
+export class StartGameHandler
+  implements ICommandHandler<StartGameCommand, GameRoom>
+{
+  constructor(
+    @Inject(GAME_ROOM_REPOSITORY)
+    private readonly gameRoomRepository: GameRoomRepositoryPort,
+    @Inject(EVENT_STORE)
+    private readonly eventStore: IEventStore,
+  ) {}
+
+  async execute(command: StartGameCommand): Promise<GameRoom> {
+    const gameRoom = await this.gameRoomRepository.findOneById(
+      command.gameRoomId,
+    );
+
+    if (gameRoom === undefined) {
+      throw new GameRoomNotFoundError();
+    }
+
+    gameRoom.start();
+
+    await this.gameRoomRepository.update(gameRoom);
+
+    await this.eventStore.storeAggregateEvents(gameRoom);
+
+    return gameRoom;
+  }
+}

--- a/src/modules/game-room/use-cases/start-game/start-game.module.ts
+++ b/src/modules/game-room/use-cases/start-game/start-game.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+
+import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+import { GameRoomAccessControlModule } from '@module/game-room/services/game-room-access-control/game-room-access-control.module';
+import { StartGameController } from '@module/game-room/use-cases/start-game/start-game.controller';
+import { StartGameHandler } from '@module/game-room/use-cases/start-game/start-game.handler';
+
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
+@Module({
+  imports: [
+    GameRoomRepositoryModule,
+    EventStoreModule,
+    GameRoomAccessControlModule,
+  ],
+  controllers: [StartGameController],
+  providers: [StartGameHandler],
+})
+export class StartGameModule {}


### PR DESCRIPTION
### Short description

게임 시작 REST API 

### Proposed changes

- 게임방 시작 대기중 상태를 ready에서 starting으로 변경
- 게임 시작 REST API 구현
   - lobby, game-room에 소켓 이벤트 퍼블리시

### How to test (Optional)

```bash
curl -X 'POST' \
  'http://localhost:3000/game-room/756745721389470573/start' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NDc3MTE4MTM3ODAxMDM0OTYiLCJyb2xlIjoidXNlciIsImlhdCI6MTc1ODE3OTE5OCwiZXhwIjoxNzg5NzM2Nzk4LCJpc3MiOiJxdWl6emVzX2dhbWVfaW9fYmFja2VuZCJ9.jaEiTiRU-nyRc69sC01hCr_6FCKIs_cruNlM7ZHLUMQ' \
  -d ''
```

### Reference (Optional)

Closes #55
