### PR TITLE
게임 방에 문제 제한시간 추가

### DIFF
--- a/prisma/migrations/20250923060324_game_room_quiz_time_limit/migration.sql
+++ b/prisma/migrations/20250923060324_game_room_quiz_time_limit/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - Added the required column `quizTimeLimitInSec` to the `game_room` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+-- 1. 새 컬럼 추가 (nullable + 임시 default 30)
+ALTER TABLE "game_room" ADD COLUMN "quizTimeLimitInSec" INTEGER DEFAULT 30;
+
+-- 2. 기존 레코드 null 값 채우기
+UPDATE "game_room" SET "quizTimeLimitInSec" = 30 WHERE "quizTimeLimitInSec" IS NULL;
+
+-- 3. NOT NULL 제약 추가
+ALTER TABLE "game_room" ALTER COLUMN "quizTimeLimitInSec" SET NOT NULL;
+
+-- 4. default 제거 (INSERT 시 반드시 명시해야 함)
+ALTER TABLE "game_room" ALTER COLUMN "quizTimeLimitInSec" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,18 +78,18 @@ model GameRoom {
 
   accountId BigInt
 
-  status              GameRoomStatus
-  visibility          GameRoomVisibility
-  title               String
-  maxMembersCount     Int                @default(0)
+  status             GameRoomStatus
+  visibility         GameRoomVisibility
+  title              String
+  maxMembersCount    Int                @default(0)
+  quizTimeLimitInSec Int
+  /// [GameRoomMember]
+  members            Json[]             @default([])
 
   createdAt DateTime @default(now()) @db.Timestamp(3)
   updatedAt DateTime @updatedAt @db.Timestamp(3)
 
   account Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
-
-  /// [GameRoomMember]
-  members Json[] @default([])
 
   @@map("game_room")
 }

--- a/src/modules/game-room/assemblers/game-room-dto.assembler.ts
+++ b/src/modules/game-room/assemblers/game-room-dto.assembler.ts
@@ -16,6 +16,7 @@ export class GameRoomDtoAssembler {
     dto.title = gameRoom.props.title;
     dto.maxMembersCount = gameRoom.props.maxMembersCount;
     dto.currentMembersCount = gameRoom.currentMembersCount;
+    dto.quizTimeLimitInSeconds = gameRoom.props.quizTimeLimitInSeconds;
 
     return dto;
   }
@@ -29,6 +30,7 @@ export class GameRoomDtoAssembler {
     dto.title = gameRoom.title;
     dto.maxPlayers = gameRoom.maxMembersCount;
     dto.currentMembersCount = gameRoom.currentMembersCount;
+    dto.quizTimeLimitInSeconds = gameRoom.props.quizTimeLimitInSeconds;
     dto.members = gameRoom.members.map((member) =>
       GameRoomMemberDtoAssembler.convertToSocketEventDto(member),
     );

--- a/src/modules/game-room/dto/game-room-socket-event.dto.ts
+++ b/src/modules/game-room/dto/game-room-socket-event.dto.ts
@@ -38,6 +38,9 @@ export class GameRoomSocketEventDto {
   @ApiProperty()
   currentMembersCount: number;
 
+  @ApiProperty()
+  quizTimeLimitInSeconds: number;
+
   @ApiProperty({
     type: [GameRoomMemberSocketEventDto],
   })

--- a/src/modules/game-room/dto/game-room.dto.ts
+++ b/src/modules/game-room/dto/game-room.dto.ts
@@ -19,4 +19,7 @@ export class GameRoomDto extends BaseResponseDto {
 
   @ApiProperty()
   currentMembersCount: number;
+
+  @ApiProperty()
+  quizTimeLimitInSeconds: number;
 }

--- a/src/modules/game-room/entities/__spec__/game-room.factory.ts
+++ b/src/modules/game-room/entities/__spec__/game-room.factory.ts
@@ -21,6 +21,7 @@ export const GameRoomFactory = Factory.define<GameRoom & GameRoomProps>(
     title: () => faker.string.nanoid(),
     maxMembersCount: () => faker.number.int({ min: 2, max: 10 }),
     members: () => [],
+    quizTimeLimitInSeconds: () => faker.number.int({ min: 10, max: 60 }),
     createdAt: () => new Date(),
     updatedAt: () => new Date(),
   })

--- a/src/modules/game-room/entities/game-room.entity.ts
+++ b/src/modules/game-room/entities/game-room.entity.ts
@@ -38,6 +38,7 @@ export interface GameRoomProps {
   visibility: GameRoomVisibility;
   title: string;
   maxMembersCount: number;
+  quizTimeLimitInSeconds: number;
   members: GameRoomMember[];
 }
 
@@ -46,11 +47,14 @@ interface CreateGameRoomProps {
   visibility: GameRoomVisibility;
   title: string;
   maxMembersCount: number;
+  quizTimeLimitInSeconds?: number;
   hostAccountId: string;
   hostNickname: string;
 }
 
 export class GameRoom extends AggregateRoot<GameRoomProps> {
+  static DEFAULT_QUIZ_TIME_LIMIT_IN_SECONDS = 30;
+
   constructor(props: CreateEntityProps<GameRoomProps>) {
     super(props);
   }
@@ -67,6 +71,9 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
         visibility: props.visibility,
         title: props.title,
         maxMembersCount: props.maxMembersCount,
+        quizTimeLimitInSeconds:
+          props.quizTimeLimitInSeconds ??
+          GameRoom.DEFAULT_QUIZ_TIME_LIMIT_IN_SECONDS,
         members: [],
       },
       createdAt: date,
@@ -81,6 +88,7 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
         title: props.title,
         maxPlayers: props.maxMembersCount,
         currentMembersCount: gameRoom.currentMembersCount,
+        quizTimeLimitInSeconds: gameRoom.props.quizTimeLimitInSeconds,
       }),
     );
 

--- a/src/modules/game-room/events/game-room-created/__spec__/game-room-created.handler.spec.ts
+++ b/src/modules/game-room/events/game-room-created/__spec__/game-room-created.handler.spec.ts
@@ -57,6 +57,7 @@ describe(GameRoomCreatedHandler, () => {
       title: gameRoom.title,
       maxPlayers: gameRoom.maxMembersCount,
       currentMembersCount: gameRoom.currentMembersCount,
+      quizTimeLimitInSeconds: gameRoom.props.quizTimeLimitInSeconds,
     });
   });
 

--- a/src/modules/game-room/events/game-room-created/game-room-created.event.ts
+++ b/src/modules/game-room/events/game-room-created/game-room-created.event.ts
@@ -12,6 +12,7 @@ interface GameRoomCreatedEventPayload {
   title: string;
   maxPlayers: number;
   currentMembersCount: number;
+  quizTimeLimitInSeconds: number;
 }
 
 export class GameRoomCreatedEvent extends DomainEvent<GameRoomCreatedEventPayload> {

--- a/src/modules/game-room/mappers/game-room.mapper.ts
+++ b/src/modules/game-room/mappers/game-room.mapper.ts
@@ -20,6 +20,7 @@ export class GameRoomMapper extends BaseMapper {
         visibility: GameRoomVisibility[raw.visibility],
         title: raw.title,
         maxMembersCount: raw.maxMembersCount,
+        quizTimeLimitInSeconds: raw.quizTimeLimitInSec,
         members: raw.members.map((member) =>
           GameRoomMemberMapper.toEntity(member),
         ),
@@ -37,6 +38,7 @@ export class GameRoomMapper extends BaseMapper {
       visibility: entity.props.visibility,
       title: entity.props.title,
       maxMembersCount: entity.props.maxMembersCount,
+      quizTimeLimitInSec: entity.props.quizTimeLimitInSeconds,
       members: entity.members.map((member) =>
         GameRoomMemberMapper.toPersistence(member),
       ),

--- a/src/modules/game-room/use-cases/create-game-room/create-game-room.handler.ts
+++ b/src/modules/game-room/use-cases/create-game-room/create-game-room.handler.ts
@@ -50,6 +50,7 @@ export class CreateGameRoomHandler
       maxMembersCount: command.maxPlayersCount,
       hostAccountId: command.currentAccountId,
       hostNickname: existingAccount.nickname,
+      quizTimeLimitInSeconds: GameRoom.DEFAULT_QUIZ_TIME_LIMIT_IN_SECONDS,
     });
 
     await this.gameRoomRepository.insert(gameRoom);


### PR DESCRIPTION
### Short description

게임 방에 문제 제한시간 추가

### Proposed changes

- 게임 방에 문제 제한시간 추가
- REST API 응답으로 퀴즈 시간 추가
- 소켓 응답으로 퀴즈 시간 추가

### How to test (Optional)

게임방 생성

```bash
curl -X 'POST' \
  'http://localhost:3000/game-rooms' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoidXNlciIsImlhdCI6MTc1ODYwNzQ2MywiZXhwIjoxNzkwMTY1MDYzLCJpc3MiOiJxdWl6emVzX2dhbWVfaW9fYmFja2VuZCJ9.GX6UVCtT81UcELxpJRvbIQwuQsjz5tmqGKPENbKQh8k' \
  -H 'Content-Type: application/json' \
  -d '{
  "title": "My Awesome Game Room"
}'
```

### Reference (Optional)

Closes #66 
