### PR TITLE
게임 방에 문제 수 추가

### DIFF
--- a/prisma/migrations/20250923060852_game_room_quizzes_count/migration.sql
+++ b/prisma/migrations/20250923060852_game_room_quizzes_count/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - Added the required column `quizzesCount` to the `game_room` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+-- 1. 새 컬럼 추가 (nullable + 임시 default 10)
+ALTER TABLE "game_room" ADD COLUMN "quizzesCount" INTEGER DEFAULT 10;
+
+-- 2. 기존 레코드 null 값 채우기
+UPDATE "game_room" SET "quizzesCount" = 10 WHERE "quizzesCount" IS NULL;
+
+-- 3. NOT NULL 제약 추가
+ALTER TABLE "game_room" ALTER COLUMN "quizzesCount" SET NOT NULL;
+
+-- 4. default 제거 (INSERT 시 반드시 값 명시 필요)
+ALTER TABLE "game_room" ALTER COLUMN "quizzesCount" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,6 +83,7 @@ model GameRoom {
   title              String
   maxMembersCount    Int                @default(0)
   quizTimeLimitInSec Int
+  quizzesCount       Int
   /// [GameRoomMember]
   members            Json[]             @default([])
 

--- a/src/modules/game-room/assemblers/game-room-dto.assembler.ts
+++ b/src/modules/game-room/assemblers/game-room-dto.assembler.ts
@@ -17,6 +17,7 @@ export class GameRoomDtoAssembler {
     dto.maxMembersCount = gameRoom.props.maxMembersCount;
     dto.currentMembersCount = gameRoom.currentMembersCount;
     dto.quizTimeLimitInSeconds = gameRoom.props.quizTimeLimitInSeconds;
+    dto.quizzesCount = gameRoom.quizzesCount;
 
     return dto;
   }
@@ -31,6 +32,7 @@ export class GameRoomDtoAssembler {
     dto.maxPlayers = gameRoom.maxMembersCount;
     dto.currentMembersCount = gameRoom.currentMembersCount;
     dto.quizTimeLimitInSeconds = gameRoom.props.quizTimeLimitInSeconds;
+    dto.quizzesCount = gameRoom.quizzesCount;
     dto.members = gameRoom.members.map((member) =>
       GameRoomMemberDtoAssembler.convertToSocketEventDto(member),
     );

--- a/src/modules/game-room/dto/game-room-socket-event.dto.ts
+++ b/src/modules/game-room/dto/game-room-socket-event.dto.ts
@@ -45,4 +45,7 @@ export class GameRoomSocketEventDto {
     type: [GameRoomMemberSocketEventDto],
   })
   members: GameRoomMemberSocketEventDto[];
+
+  @ApiProperty()
+  quizzesCount: number;
 }

--- a/src/modules/game-room/dto/game-room.dto.ts
+++ b/src/modules/game-room/dto/game-room.dto.ts
@@ -22,4 +22,7 @@ export class GameRoomDto extends BaseResponseDto {
 
   @ApiProperty()
   quizTimeLimitInSeconds: number;
+
+  @ApiProperty()
+  quizzesCount: number;
 }

--- a/src/modules/game-room/entities/__spec__/game-room.entity.spec.ts
+++ b/src/modules/game-room/entities/__spec__/game-room.entity.spec.ts
@@ -31,6 +31,7 @@ describe(GameRoom, () => {
         visibility: GameRoomVisibility.public,
         title: 'title',
         maxMembersCount: 8,
+        quizzesCount: 5,
         hostAccountId: generateEntityId(),
         hostNickname: 'nickname',
       };

--- a/src/modules/game-room/entities/__spec__/game-room.factory.ts
+++ b/src/modules/game-room/entities/__spec__/game-room.factory.ts
@@ -22,6 +22,7 @@ export const GameRoomFactory = Factory.define<GameRoom & GameRoomProps>(
     maxMembersCount: () => faker.number.int({ min: 2, max: 10 }),
     members: () => [],
     quizTimeLimitInSeconds: () => faker.number.int({ min: 10, max: 60 }),
+    quizzesCount: () => faker.number.int({ min: 10, max: 30 }),
     createdAt: () => new Date(),
     updatedAt: () => new Date(),
   })

--- a/src/modules/game-room/entities/game-room.entity.ts
+++ b/src/modules/game-room/entities/game-room.entity.ts
@@ -39,6 +39,7 @@ export interface GameRoomProps {
   title: string;
   maxMembersCount: number;
   quizTimeLimitInSeconds: number;
+  quizzesCount: number;
   members: GameRoomMember[];
 }
 
@@ -48,6 +49,7 @@ interface CreateGameRoomProps {
   title: string;
   maxMembersCount: number;
   quizTimeLimitInSeconds?: number;
+  quizzesCount: number;
   hostAccountId: string;
   hostNickname: string;
 }
@@ -74,6 +76,7 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
         quizTimeLimitInSeconds:
           props.quizTimeLimitInSeconds ??
           GameRoom.DEFAULT_QUIZ_TIME_LIMIT_IN_SECONDS,
+        quizzesCount: props.quizzesCount,
         members: [],
       },
       createdAt: date,
@@ -89,6 +92,7 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
         maxPlayers: props.maxMembersCount,
         currentMembersCount: gameRoom.currentMembersCount,
         quizTimeLimitInSeconds: gameRoom.props.quizTimeLimitInSeconds,
+        quizzesCount: gameRoom.props.quizzesCount,
       }),
     );
 
@@ -125,6 +129,10 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
 
   get currentMembersCount(): number {
     return this.props.members.length;
+  }
+
+  get quizzesCount(): number {
+    return this.props.quizzesCount;
   }
 
   get host(): GameRoomMember | undefined {

--- a/src/modules/game-room/events/game-room-created/__spec__/game-room-created.handler.spec.ts
+++ b/src/modules/game-room/events/game-room-created/__spec__/game-room-created.handler.spec.ts
@@ -58,6 +58,7 @@ describe(GameRoomCreatedHandler, () => {
       maxPlayers: gameRoom.maxMembersCount,
       currentMembersCount: gameRoom.currentMembersCount,
       quizTimeLimitInSeconds: gameRoom.props.quizTimeLimitInSeconds,
+      quizzesCount: gameRoom.quizzesCount,
     });
   });
 

--- a/src/modules/game-room/events/game-room-created/game-room-created.event.ts
+++ b/src/modules/game-room/events/game-room-created/game-room-created.event.ts
@@ -13,6 +13,7 @@ interface GameRoomCreatedEventPayload {
   maxPlayers: number;
   currentMembersCount: number;
   quizTimeLimitInSeconds: number;
+  quizzesCount: number;
 }
 
 export class GameRoomCreatedEvent extends DomainEvent<GameRoomCreatedEventPayload> {

--- a/src/modules/game-room/mappers/game-room.mapper.ts
+++ b/src/modules/game-room/mappers/game-room.mapper.ts
@@ -21,6 +21,7 @@ export class GameRoomMapper extends BaseMapper {
         title: raw.title,
         maxMembersCount: raw.maxMembersCount,
         quizTimeLimitInSeconds: raw.quizTimeLimitInSec,
+        quizzesCount: raw.quizzesCount,
         members: raw.members.map((member) =>
           GameRoomMemberMapper.toEntity(member),
         ),
@@ -39,6 +40,7 @@ export class GameRoomMapper extends BaseMapper {
       title: entity.props.title,
       maxMembersCount: entity.props.maxMembersCount,
       quizTimeLimitInSec: entity.props.quizTimeLimitInSeconds,
+      quizzesCount: entity.quizzesCount,
       members: entity.members.map((member) =>
         GameRoomMemberMapper.toPersistence(member),
       ),

--- a/src/modules/game-room/use-cases/create-game-room/__spec__/create-game-room-command.factory.ts
+++ b/src/modules/game-room/use-cases/create-game-room/__spec__/create-game-room-command.factory.ts
@@ -11,5 +11,6 @@ export const CreateGameRoomCommandFactory =
     CreateGameRoomCommand,
   ).attrs({
     currentAccountId: () => generateEntityId(),
-    title: faker.string.nanoid(),
+    title: () => faker.string.nanoid(),
+    quizzesCount: () => faker.number.int({ min: 1, max: 10 }),
   });

--- a/src/modules/game-room/use-cases/create-game-room/create-game-room.command.ts
+++ b/src/modules/game-room/use-cases/create-game-room/create-game-room.command.ts
@@ -8,11 +8,13 @@ import {
 export interface ICreateGameRoomCommandProps {
   currentAccountId: string;
   title: string;
+  quizzesCount: number;
 }
 
 export class CreateGameRoomCommand implements ICommand {
   readonly currentAccountId: string;
   readonly title: string;
+  readonly quizzesCount: number;
   readonly status: GameRoomStatus;
   readonly visibility: GameRoomVisibility;
   readonly maxPlayersCount: number;
@@ -20,6 +22,7 @@ export class CreateGameRoomCommand implements ICommand {
   constructor(props: ICreateGameRoomCommandProps) {
     this.currentAccountId = props.currentAccountId;
     this.title = props.title;
+    this.quizzesCount = props.quizzesCount;
     this.status = GameRoomStatus.waiting;
     this.visibility = GameRoomVisibility.public;
     this.maxPlayersCount = 8;

--- a/src/modules/game-room/use-cases/create-game-room/create-game-room.controller.ts
+++ b/src/modules/game-room/use-cases/create-game-room/create-game-room.controller.ts
@@ -48,6 +48,7 @@ export class CreateGameRoomController {
     const command = new CreateGameRoomCommand({
       currentAccountId: currentUser.id,
       title: body.title,
+      quizzesCount: body.quizzesCount,
     });
 
     try {

--- a/src/modules/game-room/use-cases/create-game-room/create-game-room.dto.ts
+++ b/src/modules/game-room/use-cases/create-game-room/create-game-room.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { IsNotEmpty, IsString, Length } from 'class-validator';
+import { IsInt, IsNotEmpty, IsString, Length, Max, Min } from 'class-validator';
 
 export class CreateGameRoomDto {
   @ApiProperty({
@@ -13,4 +13,13 @@ export class CreateGameRoomDto {
   @IsNotEmpty()
   @IsString()
   title: string;
+
+  @ApiProperty({
+    minimum: 10,
+    maximum: 100,
+  })
+  @Max(100)
+  @Min(10)
+  @IsInt()
+  quizzesCount: number;
 }

--- a/src/modules/game-room/use-cases/create-game-room/create-game-room.handler.ts
+++ b/src/modules/game-room/use-cases/create-game-room/create-game-room.handler.ts
@@ -47,6 +47,7 @@ export class CreateGameRoomHandler
       status: command.status,
       visibility: command.visibility,
       title: command.title,
+      quizzesCount: command.quizzesCount,
       maxMembersCount: command.maxPlayersCount,
       hostAccountId: command.currentAccountId,
       hostNickname: existingAccount.nickname,


### PR DESCRIPTION
### Short description

게임 방에 문제 수 추가

### Proposed changes

- 게임 방에 문제 수 추가
- REST API 응답으로 퀴즈 수 추가
- 소켓 응답으로 퀴즈 수 추가

### How to test (Optional)

게임방 생성

```bash
curl -X 'POST' \
  'http://localhost:3000/game-rooms' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoidXNlciIsImlhdCI6MTc1ODYwNzQ2MywiZXhwIjoxNzkwMTY1MDYzLCJpc3MiOiJxdWl6emVzX2dhbWVfaW9fYmFja2VuZCJ9.GX6UVCtT81UcELxpJRvbIQwuQsjz5tmqGKPENbKQh8k' \
  -H 'Content-Type: application/json' \
  -d '{
  "title": "My Awesome Game Room"
}'
```

### Reference (Optional)

Closes #65
