### PR TITLE
게임방 상세조회 REST API 추가

### DIFF
--- a/src/modules/game-room/use-cases/get-game-room/get-game-room.controller.ts
+++ b/src/modules/game-room/use-cases/get-game-room/get-game-room.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Controller,
+  Get,
+  HttpStatus,
+  Inject,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { AccountNotFoundError } from '@module/account/errors/account-not-found.error';
+import { JwtAuthGuard } from '@module/auth/jwt/jwt-auth.guard';
+import { GameRoomDtoAssembler } from '@module/game-room/assemblers/game-room-dto.assembler';
+import { GameRoomDto } from '@module/game-room/dto/game-room.dto';
+import { GameRoom } from '@module/game-room/entities/game-room.entity';
+import { GameRoomAccessDeniedError } from '@module/game-room/errors/game-room-access-denied.error';
+import { GameRoomNotFoundError } from '@module/game-room/errors/game-room-not-found.error';
+import {
+  GAME_ROOM_ACCESS_CONTROL_SERVICE,
+  IGameRoomAccessControlService,
+} from '@module/game-room/services/game-room-access-control/game-room-access-control.service.interface';
+import { GetGameRoomQuery } from '@module/game-room/use-cases/get-game-room/get-game-room.query';
+
+import { BaseHttpException } from '@common/base/base-http-exception';
+import { UnauthorizedError } from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import {
+  CurrentUser,
+  ICurrentUser,
+} from '@common/decorator/current-user.decorator';
+
+@ApiTags('game-room')
+@ApiBearerAuth()
+@Controller()
+export class GetGameRoomController {
+  constructor(
+    private readonly queryBus: QueryBus,
+    @Inject(GAME_ROOM_ACCESS_CONTROL_SERVICE)
+    private readonly gameRoomAccessControlService: IGameRoomAccessControlService,
+  ) {}
+
+  @ApiOperation({ summary: '게임 방 상세 조회' })
+  @ApiBearerAuth()
+  @ApiOkResponse({ type: GameRoomDto })
+  @ApiErrorResponse({
+    [HttpStatus.UNAUTHORIZED]: [UnauthorizedError],
+    [HttpStatus.FORBIDDEN]: [GameRoomAccessDeniedError],
+    [HttpStatus.NOT_FOUND]: [GameRoomNotFoundError],
+  })
+  @UseGuards(JwtAuthGuard)
+  @Get('game-rooms/:gameRoomId')
+  async getGameRoom(
+    @Param('gameRoomId') gameRoomId: string,
+    @CurrentUser() currentUser: ICurrentUser,
+  ): Promise<GameRoomDto> {
+    await this.gameRoomAccessControlService.allowMember({
+      accountId: currentUser.id,
+      gameRoomId,
+    });
+
+    const query = new GetGameRoomQuery({
+      gameRoomId,
+    });
+
+    try {
+      const gameRoom = await this.queryBus.execute<GetGameRoomQuery, GameRoom>(
+        query,
+      );
+
+      return GameRoomDtoAssembler.convertToDto(gameRoom);
+    } catch (error) {
+      if (error instanceof GameRoomAccessDeniedError) {
+        throw new BaseHttpException(HttpStatus.FORBIDDEN, error);
+      }
+
+      if (error instanceof AccountNotFoundError) {
+        throw new BaseHttpException(HttpStatus.INTERNAL_SERVER_ERROR, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/game-room/use-cases/get-game-room/get-game-room.module.ts
+++ b/src/modules/game-room/use-cases/get-game-room/get-game-room.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 
 import { GameRoomRepositoryModule } from '@module/game-room/repositories/game-room/game-room.repository.module';
+import { GameRoomAccessControlModule } from '@module/game-room/services/game-room-access-control/game-room-access-control.module';
+import { GetGameRoomController } from '@module/game-room/use-cases/get-game-room/get-game-room.controller';
 import { GetGameRoomHandler } from '@module/game-room/use-cases/get-game-room/get-game-room.handler';
 
 @Module({
-  imports: [GameRoomRepositoryModule],
+  controllers: [GetGameRoomController],
+  imports: [GameRoomAccessControlModule, GameRoomRepositoryModule],
   providers: [GetGameRoomHandler],
 })
 export class GetGameRoomModule {}


### PR DESCRIPTION
### Short description

게임방 상세조회 REST API 추가

### Proposed changes

- 게임방 상세조회 REST API 추가

### How to test (Optional)

게임 방 상세조회

```bash
curl -X 'GET' \
  'http://localhost:3000/game-rooms/758211249742879884' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoidXNlciIsImlhdCI6MTc1ODYwNzQ2MywiZXhwIjoxNzkwMTY1MDYzLCJpc3MiOiJxdWl6emVzX2dhbWVfaW9fYmFja2VuZCJ9.GX6UVCtT81UcELxpJRvbIQwuQsjz5tmqGKPENbKQh8k'
```

### Reference (Optional)

Closes #78
