### PR TITLE
게임방 응답 속성으로 구성원 콜렉션 추가

### DIFF
--- a/src/modules/game-room/assemblers/game-room-dto.assembler.ts
+++ b/src/modules/game-room/assemblers/game-room-dto.assembler.ts
@@ -18,6 +18,9 @@ export class GameRoomDtoAssembler {
     dto.currentMembersCount = gameRoom.currentMembersCount;
     dto.quizTimeLimitInSeconds = gameRoom.props.quizTimeLimitInSeconds;
     dto.quizzesCount = gameRoom.quizzesCount;
+    dto.members = gameRoom.members.map((member) =>
+      GameRoomMemberDtoAssembler.convertToDto(member),
+    );
 
     return dto;
   }

--- a/src/modules/game-room/dto/game-room.dto.ts
+++ b/src/modules/game-room/dto/game-room.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+import { GameRoomMemberDto } from '@module/game-room/dto/game-room-member.dto';
 import { GameRoomStatus } from '@module/game-room/entities/game-room.entity';
 
 import { BaseResponseDto } from '@common/base/base.dto';
@@ -25,4 +26,9 @@ export class GameRoomDto extends BaseResponseDto {
 
   @ApiProperty()
   quizzesCount: number;
+
+  @ApiProperty({
+    type: [GameRoomMemberDto],
+  })
+  members: GameRoomMemberDto[];
 }


### PR DESCRIPTION
### Short description

게임방 응답 속성으로 구성원 콜렉션 추가

### Proposed changes

- 게임방 응답 속성으로 구성원 콜렉션 추가
   - 게임방 단일 조회
   - 게임방 리스트 조회

### How to test (Optional)

게임방 단일 조회 API 호출 시 members 필드가 추가됨

```bash
curl -X 'GET' \
  'http://localhost:3000/game-rooms/758207170146457109' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoidXNlciIsImlhdCI6MTc1ODYwNzQ2MywiZXhwIjoxNzkwMTY1MDYzLCJpc3MiOiJxdWl6emVzX2dhbWVfaW9fYmFja2VuZCJ9.GX6UVCtT81UcELxpJRvbIQwuQsjz5tmqGKPENbKQh8k'
```

### Reference (Optional)

Closes #79 
