### PR TITLE
이미지 목록 조회 어드민 API

### DIFF
--- a/src/common/base/base.dto.ts
+++ b/src/common/base/base.dto.ts
@@ -33,3 +33,19 @@ export abstract class BaseCursorPaginationResponseDto<T> {
 
   abstract data: T[];
 }
+
+export abstract class BaseOffsetPaginationResponseDto<T> {
+  abstract data: T[];
+
+  @ApiProperty()
+  currentPage: number;
+
+  @ApiProperty()
+  perPage: number;
+
+  @ApiProperty()
+  totalCount: number;
+
+  @ApiProperty()
+  totalPages: number;
+}

--- a/src/common/base/base.entity.ts
+++ b/src/common/base/base.entity.ts
@@ -23,6 +23,19 @@ export type CreateEntityProps<T> = {
 
 export type TBaseEntity<T> = BaseEntity<T> | AggregateRoot<T>;
 
+export class OffsetPage<T> {
+  constructor(
+    public readonly data: T[],
+    public readonly currentPage: number,
+    public readonly perPage: number,
+    public readonly totalCount: number,
+  ) {}
+
+  get totalPages(): number {
+    return Math.ceil(this.totalCount / this.perPage);
+  }
+}
+
 export abstract class BaseEntity<T> {
   private readonly _id: EntityId;
 

--- a/src/common/base/base.repository.ts
+++ b/src/common/base/base.repository.ts
@@ -24,6 +24,18 @@ export interface ICursorPaginatedParams<
   filter?: Filter;
 }
 
+export interface IOffsetPaginated<T> {
+  offset: number;
+  limit: number;
+  totalCount: number;
+  data: T[];
+}
+
+export interface IOffsetPaginatedParams {
+  offset?: number;
+  limit?: number;
+}
+
 export interface RepositoryPort<
   E,
   ListFilter = Record<string, unknown>,

--- a/src/modules/image/assemblers/image-collection-dto.assembler.ts
+++ b/src/modules/image/assemblers/image-collection-dto.assembler.ts
@@ -1,0 +1,19 @@
+import { ImageDtoAssembler } from '@module/image/assemblers/image-dto.assembler';
+import { ImageCollectionDto } from '@module/image/dto/image.collection.dto';
+import { Image } from '@module/image/entities/image.entity';
+
+import { OffsetPage } from '@common/base/base.entity';
+
+export class ImageCollectionDtoAssembler {
+  static convertToDto(page: OffsetPage<Image>): ImageCollectionDto {
+    const dto = new ImageCollectionDto();
+
+    dto.data = page.data.map(ImageDtoAssembler.convertToDto);
+    dto.currentPage = page.currentPage;
+    dto.perPage = page.perPage;
+    dto.totalCount = page.totalCount;
+    dto.totalPages = page.totalPages;
+
+    return dto;
+  }
+}

--- a/src/modules/image/dto/image.collection.dto.ts
+++ b/src/modules/image/dto/image.collection.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ImageDto } from '@module/image/dto/image.dto';
+
+import { BaseOffsetPaginationResponseDto } from '@common/base/base.dto';
+
+export class ImageCollectionDto extends BaseOffsetPaginationResponseDto<ImageDto> {
+  @ApiProperty({
+    type: [ImageDto],
+  })
+  data: ImageDto[];
+}

--- a/src/modules/image/image.module.ts
+++ b/src/modules/image/image.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 
 import { CreateImageModule } from '@module/image/use-cases/create-image/create-image.module';
+import { ListImagesModule } from '@module/image/use-cases/list-images/list-images.module';
 
 @Module({
-  imports: [CreateImageModule],
+  imports: [CreateImageModule, ListImagesModule],
 })
 export class ImageModule {}

--- a/src/modules/image/repositories/image/__spec__/image.repository.spec.ts
+++ b/src/modules/image/repositories/image/__spec__/image.repository.spec.ts
@@ -49,4 +49,30 @@ describe(ImageRepository, () => {
       });
     });
   });
+
+  describe(ImageRepository.prototype.findAllOffsetPaginated, () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let images: Image[];
+
+    beforeEach(async () => {
+      images = await Promise.all(
+        ImageFactory.buildList(5).map((image) => repository.insert(image)),
+      );
+    });
+
+    describe('페이지를 조회하면', () => {
+      it('페이지가 반환되어야한다.', async () => {
+        await expect(
+          repository.findAllOffsetPaginated({
+            pageInfo: { offset: 0, limit: 2 },
+          }),
+        ).resolves.toEqual({
+          data: expect.toSatisfyAll((image: unknown) => image instanceof Image),
+          limit: expect.any(Number),
+          offset: expect.any(Number),
+          totalCount: expect.any(Number),
+        });
+      });
+    });
+  });
 });

--- a/src/modules/image/repositories/image/image.repository.port.ts
+++ b/src/modules/image/repositories/image/image.repository.port.ts
@@ -2,15 +2,29 @@ import { Image as ImageModel } from '@prisma/client';
 
 import { Image } from '@module/image/entities/image.entity';
 
-import { RepositoryPort } from '@common/base/base.repository';
+import { IOffsetPaginated, RepositoryPort } from '@common/base/base.repository';
 
 export const IMAGE_REPOSITORY = Symbol('IMAGE_REPOSITORY');
 
 export interface ImageRaw extends ImageModel {}
 
-export interface ImageFilter {}
+export interface ImageFilter {
+  category?: string;
+}
 
 export interface ImageOrder {}
 
+export interface FindAllImagesOffsetPaginatedParams {
+  pageInfo: {
+    offset: number;
+    limit: number;
+  };
+  filter?: ImageFilter;
+}
+
 export interface ImageRepositoryPort
-  extends RepositoryPort<Image, ImageFilter, ImageOrder> {}
+  extends RepositoryPort<Image, ImageFilter, ImageOrder> {
+  findAllOffsetPaginated(
+    params: FindAllImagesOffsetPaginatedParams,
+  ): Promise<IOffsetPaginated<Image>>;
+}

--- a/src/modules/image/use-cases/create-image/__spec__/create-image.handler.spec.ts
+++ b/src/modules/image/use-cases/create-image/__spec__/create-image.handler.spec.ts
@@ -26,9 +26,12 @@ import { EventStoreModule } from '@core/event-sourcing/event-store.module';
 describe(CreateImageHandler.name, () => {
   let handler: CreateImageHandler;
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let imageRepository: ImageRepositoryPort;
   let awsS3Adapter: AwsS3Port;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let eventStore: IEventStore;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let appConfigService: AppConfigService;
 
   let command: CreateImageCommand;

--- a/src/modules/image/use-cases/list-images/__spec__/list-images-query.factory.ts
+++ b/src/modules/image/use-cases/list-images/__spec__/list-images-query.factory.ts
@@ -1,0 +1,13 @@
+import { faker } from '@faker-js/faker';
+import { Factory } from 'rosie';
+
+import { ListImagesQuery } from '@module/image/use-cases/list-images/list-images.query';
+
+export const ListImagesQueryFactory = Factory.define<ListImagesQuery>(
+  ListImagesQuery.name,
+  ListImagesQuery,
+).attrs({
+  category: () => faker.word.noun(),
+  page: () => faker.number.int({ min: 1, max: 10 }),
+  perPage: () => faker.number.int({ min: 1, max: 50 }),
+});

--- a/src/modules/image/use-cases/list-images/__spec__/list-images.handler.spec.ts
+++ b/src/modules/image/use-cases/list-images/__spec__/list-images.handler.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ImageFactory } from '@module/image/entities/__spec__/image.factory';
+import { Image } from '@module/image/entities/image.entity';
+import { ImageRepositoryModule } from '@module/image/repositories/image/image.repository.module';
+import {
+  IMAGE_REPOSITORY,
+  ImageRepositoryPort,
+} from '@module/image/repositories/image/image.repository.port';
+import { ListImagesQueryFactory } from '@module/image/use-cases/list-images/__spec__/list-images-query.factory';
+import { ListImagesHandler } from '@module/image/use-cases/list-images/list-images.handler';
+import { ListImagesQuery } from '@module/image/use-cases/list-images/list-images.query';
+
+import { ClaModuleFactory } from '@common/factories/cls-module.factory';
+
+describe(ListImagesHandler.name, () => {
+  let handler: ListImagesHandler;
+
+  let imageRepository: ImageRepositoryPort;
+
+  let query: ListImagesQuery;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ClaModuleFactory(), ImageRepositoryModule],
+      providers: [ListImagesHandler],
+    }).compile();
+
+    handler = module.get<ListImagesHandler>(ListImagesHandler);
+
+    imageRepository = module.get<ImageRepositoryPort>(IMAGE_REPOSITORY);
+  });
+
+  beforeEach(() => {
+    query = ListImagesQueryFactory.build();
+  });
+
+  describe('이미지의 페이지를 조회하면', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let images: Image[];
+
+    beforeEach(async () => {
+      images = await Promise.all(
+        ImageFactory.buildList(5).map((image) => imageRepository.insert(image)),
+      );
+    });
+
+    it('이미지의 페이지가 반환돼야한다.', async () => {
+      const result = await handler.execute(query);
+
+      expect(result).toBeDefined();
+      expect(result.data.length).toBeGreaterThanOrEqual(0);
+      expect(result.currentPage).toBe(query.page ?? 1);
+      expect(result.perPage).toBe(query.perPage ?? 20);
+      expect(result.totalCount).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/src/modules/image/use-cases/list-images/list-images.controller.ts
+++ b/src/modules/image/use-cases/list-images/list-images.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Get, HttpStatus, Query, UseGuards } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '@module/auth/jwt/jwt-auth.guard';
+import { ImageCollectionDtoAssembler } from '@module/image/assemblers/image-collection-dto.assembler';
+import { ImageDto } from '@module/image/dto/image.dto';
+import { Image } from '@module/image/entities/image.entity';
+import { ListImagesDto } from '@module/image/use-cases/list-images/list-images.dto';
+import { ListImagesQuery } from '@module/image/use-cases/list-images/list-images.query';
+
+import { OffsetPage } from '@common/base/base.entity';
+import {
+  PermissionDeniedError,
+  RequestValidationError,
+  UnauthorizedError,
+} from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import { AdminGuard } from '@common/guards/admin.guard';
+
+@ApiTags('image')
+@Controller()
+export class ListImagesController {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+  })
+  @ApiOperation({ summary: '이미지 리스트 조회' })
+  @ApiBearerAuth()
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+    [HttpStatus.UNAUTHORIZED]: [UnauthorizedError],
+    [HttpStatus.FORBIDDEN]: [PermissionDeniedError],
+  })
+  @ApiOkResponse({ type: ImageDto })
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Get('admin/images')
+  async listImagesAdmin(@Query() dto: ListImagesDto) {
+    const query = new ListImagesQuery({
+      category: dto.category,
+      page: dto.page,
+      perPage: dto.perPage,
+    });
+
+    const offsetPage = await this.queryBus.execute<
+      ListImagesQuery,
+      OffsetPage<Image>
+    >(query);
+
+    return ImageCollectionDtoAssembler.convertToDto(offsetPage);
+  }
+}

--- a/src/modules/image/use-cases/list-images/list-images.dto.ts
+++ b/src/modules/image/use-cases/list-images/list-images.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class ListImagesDto {
+  @ApiProperty({
+    description: '카테고리 필터링',
+    required: false,
+  })
+  @IsNotEmpty()
+  @IsString()
+  @IsOptional()
+  category?: string;
+
+  @ApiProperty({
+    required: false,
+    minimum: 1,
+  })
+  @Min(1)
+  @IsInt()
+  @IsOptional()
+  @Type(() => Number)
+  page?: number;
+
+  @ApiProperty({
+    required: false,
+    minimum: 5,
+    maximum: 1000,
+    default: 20,
+  })
+  @Max(1000)
+  @Min(5)
+  @IsInt()
+  @IsOptional()
+  @Type(() => Number)
+  perPage?: number;
+}

--- a/src/modules/image/use-cases/list-images/list-images.handler.ts
+++ b/src/modules/image/use-cases/list-images/list-images.handler.ts
@@ -1,0 +1,38 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { Image } from '@module/image/entities/image.entity';
+import {
+  IMAGE_REPOSITORY,
+  ImageRepositoryPort,
+} from '@module/image/repositories/image/image.repository.port';
+import { ListImagesQuery } from '@module/image/use-cases/list-images/list-images.query';
+
+import { OffsetPage } from '@common/base/base.entity';
+
+@QueryHandler(ListImagesQuery)
+export class ListImagesHandler
+  implements IQueryHandler<ListImagesQuery, OffsetPage<Image>>
+{
+  constructor(
+    @Inject(IMAGE_REPOSITORY)
+    private readonly imageRepository: ImageRepositoryPort,
+  ) {}
+
+  async execute(query: ListImagesQuery): Promise<OffsetPage<Image>> {
+    const page = query.page ?? 1;
+    const perPage = query.perPage ?? 20;
+
+    const result = await this.imageRepository.findAllOffsetPaginated({
+      pageInfo: {
+        offset: (page - 1) * perPage,
+        limit: perPage,
+      },
+      filter: {
+        category: query.category,
+      },
+    });
+
+    return new OffsetPage(result.data, page, perPage, result.totalCount);
+  }
+}

--- a/src/modules/image/use-cases/list-images/list-images.module.ts
+++ b/src/modules/image/use-cases/list-images/list-images.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { ImageRepositoryModule } from '@module/image/repositories/image/image.repository.module';
+import { ListImagesController } from '@module/image/use-cases/list-images/list-images.controller';
+import { ListImagesHandler } from '@module/image/use-cases/list-images/list-images.handler';
+
+@Module({
+  imports: [ImageRepositoryModule],
+  controllers: [ListImagesController],
+  providers: [ListImagesHandler],
+})
+export class ListImagesModule {}

--- a/src/modules/image/use-cases/list-images/list-images.query.ts
+++ b/src/modules/image/use-cases/list-images/list-images.query.ts
@@ -1,0 +1,19 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export interface IListImagesQueryProps {
+  category?: string;
+  page?: number;
+  perPage?: number;
+}
+
+export class ListImagesQuery implements IQuery {
+  readonly category?: string;
+  readonly page?: number;
+  readonly perPage?: number;
+
+  constructor(props: IListImagesQueryProps) {
+    this.category = props.category;
+    this.page = props.page;
+    this.perPage = props.perPage;
+  }
+}


### PR DESCRIPTION
### Short description

이미지 목록 조회 어드민 API

### Proposed changes

- 이미지 목록 조회 어드민 API
   - 오프셋 리밋 기반 페이지네이션을 제공함

### How to test (Optional)

```bash
curl -X 'GET' \
  'http://localhost:3000/admin/images?page=1&perPage=5' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NTkxMzE2NDcsImV4cCI6MTc5MDY4OTI0NywiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.6BfML2_yiZOiySmrfeAxua-KPLRihqfOAf8OBoVMawg'
```

### Reference (Optional)

Closes #102 
