### PR TITLE
닉네임 소스 조회 어드민 API

### DIFF
--- a/src/modules/nickname-source/errors/nickname-source-not-found.error.ts
+++ b/src/modules/nickname-source/errors/nickname-source-not-found.error.ts
@@ -1,0 +1,12 @@
+import { BaseError } from '@common/base/base.error';
+
+export class NicknameSourceNotFoundError extends BaseError {
+  static CODE = 'NICKNAME_SOURCE.NOT_FOUND';
+
+  constructor(message?: string) {
+    super(
+      message ?? 'Nickname source not found',
+      NicknameSourceNotFoundError.CODE,
+    );
+  }
+}

--- a/src/modules/nickname-source/nickname-source.module.ts
+++ b/src/modules/nickname-source/nickname-source.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { CreateNicknameSourceModule } from '@module/nickname-source/use-cases/create-nickname-source/create-nickname-source.module';
+import { GetNicknameSourceModule } from '@module/nickname-source/use-cases/get-source/get-source.module';
 import { ListNicknameSourcesModule } from '@module/nickname-source/use-cases/list-nickname-sources/list-nickname-sources.module';
 
 @Module({
-  imports: [CreateNicknameSourceModule, ListNicknameSourcesModule],
+  imports: [
+    CreateNicknameSourceModule,
+    GetNicknameSourceModule,
+    ListNicknameSourcesModule,
+  ],
 })
 export class NicknameSourceModule {}

--- a/src/modules/nickname-source/use-cases/get-source/__spec__/get-source-query.factory.ts
+++ b/src/modules/nickname-source/use-cases/get-source/__spec__/get-source-query.factory.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'rosie';
+
+import { GetNicknameSourceQuery } from '@module/nickname-source/use-cases/get-source/get-source.query';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+export const GetNicknameSourceQueryFactory =
+  Factory.define<GetNicknameSourceQuery>(
+    GetNicknameSourceQuery.name,
+    GetNicknameSourceQuery,
+  ).attrs({
+    nicknameSourceId: () => generateEntityId(),
+  });

--- a/src/modules/nickname-source/use-cases/get-source/__spec__/get-source.handler.spec.ts
+++ b/src/modules/nickname-source/use-cases/get-source/__spec__/get-source.handler.spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { NicknameSourceFactory } from '@module/nickname-source/entities/__spec__/nickname-source.factory';
+import { NicknameSourceNotFoundError } from '@module/nickname-source/errors/nickname-source-not-found.error';
+import { NicknameSourceRepositoryModule } from '@module/nickname-source/repositories/nickname-source/nickname-source.repository.module';
+import {
+  NICKNAME_SOURCE_REPOSITORY,
+  NicknameSourceRepositoryPort,
+} from '@module/nickname-source/repositories/nickname-source/nickname-source.repository.port';
+import { GetNicknameSourceQueryFactory } from '@module/nickname-source/use-cases/get-source/__spec__/get-source-query.factory';
+import { GetNicknameSourceHandler } from '@module/nickname-source/use-cases/get-source/get-source.handler';
+import { GetNicknameSourceQuery } from '@module/nickname-source/use-cases/get-source/get-source.query';
+
+import { ClsModuleFactory } from '@common/factories/cls-module.factory';
+
+describe(GetNicknameSourceHandler.name, () => {
+  let handler: GetNicknameSourceHandler;
+
+  let nicknameSourceRepository: NicknameSourceRepositoryPort;
+
+  let query: GetNicknameSourceQuery;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ClsModuleFactory(), NicknameSourceRepositoryModule],
+      providers: [GetNicknameSourceHandler],
+    }).compile();
+
+    handler = module.get<GetNicknameSourceHandler>(GetNicknameSourceHandler);
+
+    nicknameSourceRepository = module.get<NicknameSourceRepositoryPort>(
+      NICKNAME_SOURCE_REPOSITORY,
+    );
+  });
+
+  beforeEach(() => {
+    query = GetNicknameSourceQueryFactory.build();
+  });
+
+  describe('닉네임 소스를 조회하면', () => {
+    beforeEach(async () => {
+      await nicknameSourceRepository.insert(
+        NicknameSourceFactory.build({ id: query.nicknameSourceId }),
+      );
+    });
+
+    it('닉네임 소스가 반환되어야한다.', async () => {
+      await expect(handler.execute(query)).resolves.toEqual(
+        expect.objectContaining({
+          id: query.nicknameSourceId,
+        }),
+      );
+    });
+  });
+
+  describe('닉네임 소스가 존재하지 않는 경우', () => {
+    it('닉네임 소스가 존재하지 않는다는 에러가 발생해야한다.', async () => {
+      await expect(handler.execute(query)).rejects.toThrow(
+        NicknameSourceNotFoundError,
+      );
+    });
+  });
+});

--- a/src/modules/nickname-source/use-cases/get-source/get-source.controller.ts
+++ b/src/modules/nickname-source/use-cases/get-source/get-source.controller.ts
@@ -1,0 +1,61 @@
+import { Controller, Get, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '@module/auth/jwt/jwt-auth.guard';
+import { NicknameSourceDtoAssembler } from '@module/nickname-source/assemblers/nickname-source-dto.assembler';
+import { NicknameSourceDto } from '@module/nickname-source/dto/nickname-source.dto';
+import { NicknameSource } from '@module/nickname-source/entities/nickname-source.entity';
+import { NicknameSourceNotFoundError } from '@module/nickname-source/errors/nickname-source-not-found.error';
+import { GetNicknameSourceQuery } from '@module/nickname-source/use-cases/get-source/get-source.query';
+
+import { BaseHttpException } from '@common/base/base-http-exception';
+import {
+  PermissionDeniedError,
+  RequestValidationError,
+  UnauthorizedError,
+} from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import { AdminGuard } from '@common/guards/admin.guard';
+
+@ApiTags('nickname-source')
+@Controller()
+export class GetNicknameSourceController {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  @ApiOperation({ summary: '닉네임 소스 조회' })
+  @ApiBearerAuth()
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+    [HttpStatus.UNAUTHORIZED]: [UnauthorizedError],
+    [HttpStatus.FORBIDDEN]: [PermissionDeniedError],
+  })
+  @ApiOkResponse({ type: NicknameSourceDto })
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Get('admin/nickname-sources/:nicknameSourceId')
+  async getNicknameSourceAdmin(
+    @Param('nicknameSourceId') nicknameSourceId: string,
+  ): Promise<NicknameSourceDto> {
+    try {
+      const query = new GetNicknameSourceQuery({ nicknameSourceId });
+
+      const nicknameSource = await this.queryBus.execute<
+        GetNicknameSourceQuery,
+        NicknameSource
+      >(query);
+
+      return NicknameSourceDtoAssembler.convertToDto(nicknameSource);
+    } catch (error) {
+      if (error instanceof NicknameSourceNotFoundError) {
+        throw new BaseHttpException(HttpStatus.NOT_FOUND, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/nickname-source/use-cases/get-source/get-source.handler.ts
+++ b/src/modules/nickname-source/use-cases/get-source/get-source.handler.ts
@@ -1,0 +1,31 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { NicknameSourceNotFoundError } from '@module/nickname-source/errors/nickname-source-not-found.error';
+import {
+  NICKNAME_SOURCE_REPOSITORY,
+  NicknameSourceRepositoryPort,
+} from '@module/nickname-source/repositories/nickname-source/nickname-source.repository.port';
+import { GetNicknameSourceQuery } from '@module/nickname-source/use-cases/get-source/get-source.query';
+
+@QueryHandler(GetNicknameSourceQuery)
+export class GetNicknameSourceHandler
+  implements IQueryHandler<GetNicknameSourceQuery, unknown>
+{
+  constructor(
+    @Inject(NICKNAME_SOURCE_REPOSITORY)
+    private readonly nicknameSourceRepository: NicknameSourceRepositoryPort,
+  ) {}
+
+  async execute(query: GetNicknameSourceQuery): Promise<unknown> {
+    const nicknameSOurce = await this.nicknameSourceRepository.findOneById(
+      query.nicknameSourceId,
+    );
+
+    if (nicknameSOurce === undefined) {
+      throw new NicknameSourceNotFoundError();
+    }
+
+    return nicknameSOurce;
+  }
+}

--- a/src/modules/nickname-source/use-cases/get-source/get-source.module.ts
+++ b/src/modules/nickname-source/use-cases/get-source/get-source.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { NicknameSourceRepositoryModule } from '@module/nickname-source/repositories/nickname-source/nickname-source.repository.module';
+import { GetNicknameSourceController } from '@module/nickname-source/use-cases/get-source/get-source.controller';
+import { GetNicknameSourceHandler } from '@module/nickname-source/use-cases/get-source/get-source.handler';
+
+@Module({
+  imports: [NicknameSourceRepositoryModule],
+  controllers: [GetNicknameSourceController],
+  providers: [GetNicknameSourceHandler],
+})
+export class GetNicknameSourceModule {}

--- a/src/modules/nickname-source/use-cases/get-source/get-source.query.ts
+++ b/src/modules/nickname-source/use-cases/get-source/get-source.query.ts
@@ -1,0 +1,13 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export interface IGetNicknameSourceQueryProps {
+  nicknameSourceId: string;
+}
+
+export class GetNicknameSourceQuery implements IQuery {
+  readonly nicknameSourceId: string;
+
+  constructor(props: IGetNicknameSourceQueryProps) {
+    this.nicknameSourceId = props.nicknameSourceId;
+  }
+}


### PR DESCRIPTION
### Short description

닉네임 소스 조회 어드민 API

### Proposed changes

- 닉네임 소스 조회 어드민 API

### How to test (Optional)

```bash
curl -X 'GET' \
  'http://localhost:3000/admin/nickname-sources/765802595172790018' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NTkxMzE2NDcsImV4cCI6MTc5MDY4OTI0NywiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.6BfML2_yiZOiySmrfeAxua-KPLRihqfOAf8OBoVMawg'
```

### Reference (Optional)

Closes #108 
