### PR TITLE
닉네임 소스 삭제 어드민 API

### DIFF
--- a/src/modules/nickname-source/entities/nickname-source.entity.ts
+++ b/src/modules/nickname-source/entities/nickname-source.entity.ts
@@ -1,4 +1,5 @@
 import { NicknameSourceCreatedEvent } from '@module/nickname-source/events/nickname-source-created.event';
+import { NicknameSourceDeletedEvent } from '@module/nickname-source/events/nickname-source-deleted.event';
 import { NicknameSourceUpdatedEvent } from '@module/nickname-source/events/nickname-source-updated.event';
 
 import {
@@ -71,6 +72,14 @@ export class NicknameSource extends AggregateRoot<NicknameSourceProps> {
       new NicknameSourceUpdatedEvent(this.id, {
         nicknameSourceId: this.id,
         name: props.name,
+      }),
+    );
+  }
+
+  delete() {
+    this.apply(
+      new NicknameSourceDeletedEvent(this.id, {
+        nicknameSourceId: this.id,
       }),
     );
   }

--- a/src/modules/nickname-source/events/nickname-source-deleted.event.ts
+++ b/src/modules/nickname-source/events/nickname-source-deleted.event.ts
@@ -1,0 +1,9 @@
+import { DomainEvent } from '@common/base/base.domain-event';
+
+interface NicknameSourceDeletedEventPayload {
+  nicknameSourceId: string;
+}
+
+export class NicknameSourceDeletedEvent extends DomainEvent<NicknameSourceDeletedEventPayload> {
+  readonly aggregate = 'NicknameSource';
+}

--- a/src/modules/nickname-source/nickname-source.module.ts
+++ b/src/modules/nickname-source/nickname-source.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { CreateNicknameSourceModule } from '@module/nickname-source/use-cases/create-nickname-source/create-nickname-source.module';
+import { DeleteNicknameSourceModule } from '@module/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.module';
 import { GetNicknameSourceModule } from '@module/nickname-source/use-cases/get-nickname-source/get-nickname-source.module';
 import { ListNicknameSourcesModule } from '@module/nickname-source/use-cases/list-nickname-sources/list-nickname-sources.module';
 import { UpdateNicknameSourceModule } from '@module/nickname-source/use-cases/update-nickname-source/update-nickname-source.module';
@@ -8,6 +9,7 @@ import { UpdateNicknameSourceModule } from '@module/nickname-source/use-cases/up
 @Module({
   imports: [
     CreateNicknameSourceModule,
+    DeleteNicknameSourceModule,
     GetNicknameSourceModule,
     ListNicknameSourcesModule,
     UpdateNicknameSourceModule,

--- a/src/modules/nickname-source/use-cases/delete-nickname-source/__spec__/delete-nickname-source-command.factory.ts
+++ b/src/modules/nickname-source/use-cases/delete-nickname-source/__spec__/delete-nickname-source-command.factory.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'rosie';
+
+import { DeleteNicknameSourceCommand } from '@module/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.command';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+export const DeleteNicknameSourceCommandFactory =
+  Factory.define<DeleteNicknameSourceCommand>(
+    DeleteNicknameSourceCommand.name,
+    DeleteNicknameSourceCommand,
+  ).attrs({
+    nicknameSourceId: () => generateEntityId(),
+  });

--- a/src/modules/nickname-source/use-cases/delete-nickname-source/__spec__/delete-nickname-source.handler.spec.ts
+++ b/src/modules/nickname-source/use-cases/delete-nickname-source/__spec__/delete-nickname-source.handler.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { NicknameSourceFactory } from '@module/nickname-source/entities/__spec__/nickname-source.factory';
+import { NicknameSourceNotFoundError } from '@module/nickname-source/errors/nickname-source-not-found.error';
+import { NicknameSourceRepositoryModule } from '@module/nickname-source/repositories/nickname-source/nickname-source.repository.module';
+import {
+  NICKNAME_SOURCE_REPOSITORY,
+  NicknameSourceRepositoryPort,
+} from '@module/nickname-source/repositories/nickname-source/nickname-source.repository.port';
+import { DeleteNicknameSourceCommandFactory } from '@module/nickname-source/use-cases/delete-nickname-source/__spec__/delete-nickname-source-command.factory';
+import { DeleteNicknameSourceCommand } from '@module/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.command';
+import { DeleteNicknameSourceHandler } from '@module/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.handler';
+
+import { ClsModuleFactory } from '@common/factories/cls-module.factory';
+
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
+describe(DeleteNicknameSourceHandler.name, () => {
+  let handler: DeleteNicknameSourceHandler;
+
+  let nicknameSourceRepository: NicknameSourceRepositoryPort;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let eventStore: IEventStore;
+
+  let command: DeleteNicknameSourceCommand;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ClsModuleFactory(),
+        NicknameSourceRepositoryModule,
+        EventStoreModule,
+      ],
+      providers: [DeleteNicknameSourceHandler],
+    }).compile();
+
+    handler = module.get<DeleteNicknameSourceHandler>(
+      DeleteNicknameSourceHandler,
+    );
+
+    nicknameSourceRepository = module.get<NicknameSourceRepositoryPort>(
+      NICKNAME_SOURCE_REPOSITORY,
+    );
+    eventStore = module.get<IEventStore>(EVENT_STORE);
+  });
+
+  beforeEach(() => {
+    command = DeleteNicknameSourceCommandFactory.build();
+  });
+
+  describe('닉네임 소스를 삭제하면', () => {
+    beforeEach(async () => {
+      await nicknameSourceRepository.insert(
+        NicknameSourceFactory.build({ id: command.nicknameSourceId }),
+      );
+    });
+
+    it('닉네임 소스가 삭제되어야한다.', async () => {
+      await expect(handler.execute(command)).resolves.toBeUndefined();
+
+      await expect(
+        nicknameSourceRepository.findOneById(command.nicknameSourceId),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('닉네임 소스가 존재하지 않는 경우', () => {
+    it('닉네임 소스가 존재하지 않는다는 에러가 발생해야한다.', async () => {
+      await expect(handler.execute(command)).rejects.toThrow(
+        NicknameSourceNotFoundError,
+      );
+    });
+  });
+});

--- a/src/modules/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.command.ts
+++ b/src/modules/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.command.ts
@@ -1,0 +1,13 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export interface IDeleteNicknameSourceCommandProps {
+  nicknameSourceId: string;
+}
+
+export class DeleteNicknameSourceCommand implements ICommand {
+  readonly nicknameSourceId: string;
+
+  constructor(props: IDeleteNicknameSourceCommandProps) {
+    this.nicknameSourceId = props.nicknameSourceId;
+  }
+}

--- a/src/modules/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.controller.ts
+++ b/src/modules/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import {
+  ApiBearerAuth,
+  ApiNoContentResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '@module/auth/jwt/jwt-auth.guard';
+import { NicknameSource } from '@module/nickname-source/entities/nickname-source.entity';
+import { NicknameSourceNotFoundError } from '@module/nickname-source/errors/nickname-source-not-found.error';
+import { DeleteNicknameSourceCommand } from '@module/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.command';
+
+import { BaseHttpException } from '@common/base/base-http-exception';
+import {
+  PermissionDeniedError,
+  RequestValidationError,
+  UnauthorizedError,
+} from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import { AdminGuard } from '@common/guards/admin.guard';
+
+@ApiTags('nickname-source')
+@Controller()
+export class DeleteNicknameSourceController {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  @ApiOperation({ summary: '닉네임 소스 삭제' })
+  @ApiBearerAuth()
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+    [HttpStatus.UNAUTHORIZED]: [UnauthorizedError],
+    [HttpStatus.FORBIDDEN]: [PermissionDeniedError],
+    [HttpStatus.NOT_FOUND]: [NicknameSourceNotFoundError],
+  })
+  @ApiNoContentResponse()
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Delete('admin/nickname-sources/:nicknameSourceId')
+  async deleteNicknameSource(
+    @Param('nicknameSourceId') nicknameSourceId: string,
+  ): Promise<void> {
+    try {
+      const command = new DeleteNicknameSourceCommand({
+        nicknameSourceId,
+      });
+
+      await this.commandBus.execute<
+        DeleteNicknameSourceCommand,
+        NicknameSource
+      >(command);
+    } catch (error) {
+      if (error instanceof NicknameSourceNotFoundError) {
+        throw new BaseHttpException(HttpStatus.NOT_FOUND, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.handler.ts
+++ b/src/modules/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.handler.ts
@@ -1,0 +1,45 @@
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { Transactional } from '@nestjs-cls/transactional';
+
+import { NicknameSourceNotFoundError } from '@module/nickname-source/errors/nickname-source-not-found.error';
+import {
+  NICKNAME_SOURCE_REPOSITORY,
+  NicknameSourceRepositoryPort,
+} from '@module/nickname-source/repositories/nickname-source/nickname-source.repository.port';
+import { DeleteNicknameSourceCommand } from '@module/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.command';
+
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+
+@CommandHandler(DeleteNicknameSourceCommand)
+export class DeleteNicknameSourceHandler
+  implements ICommandHandler<DeleteNicknameSourceCommand, void>
+{
+  constructor(
+    @Inject(NICKNAME_SOURCE_REPOSITORY)
+    private readonly nicknameSourceRepository: NicknameSourceRepositoryPort,
+    @Inject(EVENT_STORE)
+    private readonly eventStore: IEventStore,
+  ) {}
+
+  @Transactional()
+  async execute(command: DeleteNicknameSourceCommand): Promise<void> {
+    const nicknameSource = await this.nicknameSourceRepository.findOneById(
+      command.nicknameSourceId,
+    );
+
+    if (nicknameSource === undefined) {
+      throw new NicknameSourceNotFoundError();
+    }
+
+    nicknameSource.delete();
+
+    await this.nicknameSourceRepository.delete(nicknameSource);
+
+    await this.eventStore.storeAggregateEvents(nicknameSource);
+  }
+}

--- a/src/modules/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.module.ts
+++ b/src/modules/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { NicknameSourceRepositoryModule } from '@module/nickname-source/repositories/nickname-source/nickname-source.repository.module';
+import { DeleteNicknameSourceController } from '@module/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.controller';
+import { DeleteNicknameSourceHandler } from '@module/nickname-source/use-cases/delete-nickname-source/delete-nickname-source.handler';
+
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
+@Module({
+  imports: [NicknameSourceRepositoryModule, EventStoreModule],
+  controllers: [DeleteNicknameSourceController],
+  providers: [DeleteNicknameSourceHandler],
+})
+export class DeleteNicknameSourceModule {}


### PR DESCRIPTION
### Short description

닉네임 소스 삭제 어드민 API

### Proposed changes

- 닉네임 소스 삭제 어드민 API

### How to test (Optional)

```bash
curl -X 'DELETE' \
  'http://localhost:3000/admin/nickname-sources/765809747151218797' \
  -H 'accept: */*' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NTkxMzE2NDcsImV4cCI6MTc5MDY4OTI0NywiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.6BfML2_yiZOiySmrfeAxua-KPLRihqfOAf8OBoVMawg'
```

### Reference (Optional)

Closes #107 
