### PR TITLE
이미지 생성 시 원본 이미지 이름이 깨지는 문제 수정

### DIFF
--- a/src/modules/image/use-cases/create-image/create-image.controller.ts
+++ b/src/modules/image/use-cases/create-image/create-image.controller.ts
@@ -52,7 +52,9 @@ export class CreateImageController {
     const command = new CreateImageCommand({
       category: dto.category,
       buffer: dto.file.buffer,
-      originalFileName: dto.file.originalName,
+      originalFileName: Buffer.from(dto.file.originalName, 'ascii').toString(
+        'utf8',
+      ),
       width: imageDimensions.width,
       height: imageDimensions.height,
       extension: imageDimensions.type as string,


### PR DESCRIPTION
### Short description

이미지 생성 시 원본 이미지 이름이 깨지는 문제 수정
한글 파일명을 브라우저에서 업로드 시 인코딩문제로 이름이 깨지는 문제 수정

### Proposed changes

- 이미지 생성 시 원본 이미지 이름이 깨지는 문제 수정

### How to test (Optional)

```bash
curl -X 'POST' \
  'http://localhost:3000/admin/images' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NTkxMzE2NDcsImV4cCI6MTc5MDY4OTI0NywiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.6BfML2_yiZOiySmrfeAxua-KPLRihqfOAf8OBoVMawg' \
  -H 'Content-Type: multipart/form-data' \
  -F 'file=@스크린샷 2025-09-24 오전 11.23.56.png;type=image/png' \
  -F 'category=string'
```

### Reference (Optional)

Closes #129 
