### PR TITLE
퀴즈 이미지 단일 조회 어드민 API

### DIFF
--- a/src/modules/quiz-image/quiz-image.module.ts
+++ b/src/modules/quiz-image/quiz-image.module.ts
@@ -2,9 +2,15 @@ import { Module } from '@nestjs/common';
 
 import { CreateQuizImageModule } from '@module/quiz-image/use-cases/create-quiz-image/create-quiz-image.module';
 import { DeleteQuizImageModule } from '@module/quiz-image/use-cases/delete-quiz-image/delete-quiz-image.module';
+import { GetQuizImageModule } from '@module/quiz-image/use-cases/get-quiz-image/get-quiz-image.module';
 import { ListQuizImagesModule } from '@module/quiz-image/use-cases/list-quiz-images/list-quiz-images.module';
 
 @Module({
-  imports: [CreateQuizImageModule, DeleteQuizImageModule, ListQuizImagesModule],
+  imports: [
+    CreateQuizImageModule,
+    DeleteQuizImageModule,
+    GetQuizImageModule,
+    ListQuizImagesModule,
+  ],
 })
 export class QuizImageModule {}

--- a/src/modules/quiz-image/use-cases/get-quiz-image/__spec__/get-quiz-image-query.factory.ts
+++ b/src/modules/quiz-image/use-cases/get-quiz-image/__spec__/get-quiz-image-query.factory.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'rosie';
+
+import { GetQuizImageQuery } from '@module/quiz-image/use-cases/get-quiz-image/get-quiz-image.query';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+export const GetQuizImageQueryFactory = Factory.define<GetQuizImageQuery>(
+  GetQuizImageQuery.name,
+  GetQuizImageQuery,
+).attrs({
+  quizImageId: () => generateEntityId(),
+});

--- a/src/modules/quiz-image/use-cases/get-quiz-image/__spec__/get-quiz-image.handler.spec.ts
+++ b/src/modules/quiz-image/use-cases/get-quiz-image/__spec__/get-quiz-image.handler.spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { QuizImageFactory } from '@module/quiz-image/entities/__spec__/quiz-image.factory';
+import { QuizImageNotFoundError } from '@module/quiz-image/errors/quiz-image-not-found.error';
+import { QuizImageRepositoryModule } from '@module/quiz-image/repositories/quiz-image/quiz-image.repository.module';
+import {
+  QUIZ_IMAGE_REPOSITORY,
+  QuizImageRepositoryPort,
+} from '@module/quiz-image/repositories/quiz-image/quiz-image.repository.port';
+import { GetQuizImageQueryFactory } from '@module/quiz-image/use-cases/get-quiz-image/__spec__/get-quiz-image-query.factory';
+import { GetQuizImageHandler } from '@module/quiz-image/use-cases/get-quiz-image/get-quiz-image.handler';
+import { GetQuizImageQuery } from '@module/quiz-image/use-cases/get-quiz-image/get-quiz-image.query';
+
+import { ClsModuleFactory } from '@common/factories/cls-module.factory';
+
+describe(GetQuizImageHandler.name, () => {
+  let handler: GetQuizImageHandler;
+
+  let quizImageRepository: QuizImageRepositoryPort;
+
+  let query: GetQuizImageQuery;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ClsModuleFactory(), QuizImageRepositoryModule],
+      providers: [GetQuizImageHandler],
+    }).compile();
+
+    handler = module.get<GetQuizImageHandler>(GetQuizImageHandler);
+
+    quizImageRepository = module.get<QuizImageRepositoryPort>(
+      QUIZ_IMAGE_REPOSITORY,
+    );
+  });
+
+  beforeEach(() => {
+    query = GetQuizImageQueryFactory.build();
+  });
+
+  describe('식별자와 일치하는 퀴즈 이미지를 조회하면', () => {
+    beforeEach(async () => {
+      await quizImageRepository.insert(
+        QuizImageFactory.build({ id: query.quizImageId }),
+      );
+    });
+
+    it('퀴즈 이미지가 조회돼야한다.', async () => {
+      await expect(handler.execute(query)).resolves.toEqual(
+        expect.objectContaining({
+          id: query.quizImageId,
+        }),
+      );
+    });
+  });
+
+  describe('식별자와 일치하는 퀴즈 이미지가 존재하지 않는 경우', () => {
+    it('퀴즈 이미지가 존재하지 않는다는 에러가 발생해야한다.', async () => {
+      await expect(handler.execute(query)).rejects.toThrow(
+        QuizImageNotFoundError,
+      );
+    });
+  });
+});

--- a/src/modules/quiz-image/use-cases/get-quiz-image/get-quiz-image.controller.ts
+++ b/src/modules/quiz-image/use-cases/get-quiz-image/get-quiz-image.controller.ts
@@ -1,0 +1,65 @@
+import { Controller, Get, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '@module/auth/jwt/jwt-auth.guard';
+import { QuizImageDtoAssembler } from '@module/quiz-image/assemblers/quiz-image-dto.assembler';
+import { QuizImageDto } from '@module/quiz-image/dto/quiz-image.dto';
+import { QuizImage } from '@module/quiz-image/entities/quiz-image.entity';
+import { QuizImageNotFoundError } from '@module/quiz-image/errors/quiz-image-not-found.error';
+import { GetQuizImageQuery } from '@module/quiz-image/use-cases/get-quiz-image/get-quiz-image.query';
+import { QuizDto } from '@module/quiz/dto/quiz.dto';
+
+import { BaseHttpException } from '@common/base/base-http-exception';
+import {
+  PermissionDeniedError,
+  RequestValidationError,
+  UnauthorizedError,
+} from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import { AdminGuard } from '@common/guards/admin.guard';
+
+@ApiTags('quiz-image')
+@Controller()
+export class GetQuizImageController {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  @ApiOperation({ summary: '퀴즈 이미지 단건 조회' })
+  @ApiBearerAuth()
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+    [HttpStatus.UNAUTHORIZED]: [UnauthorizedError],
+    [HttpStatus.FORBIDDEN]: [PermissionDeniedError],
+    [HttpStatus.NOT_FOUND]: [QuizImageNotFoundError],
+  })
+  @ApiOkResponse({ type: QuizDto })
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Get('admin/quiz-images/:quizImageId')
+  async getQuizImage(
+    @Param('quizImageId') quizImageId: string,
+  ): Promise<QuizImageDto> {
+    try {
+      const query = new GetQuizImageQuery({
+        quizImageId,
+      });
+
+      const quizImage = await this.queryBus.execute<
+        GetQuizImageQuery,
+        QuizImage
+      >(query);
+
+      return QuizImageDtoAssembler.convertToDto(quizImage);
+    } catch (error) {
+      if (error instanceof QuizImageNotFoundError) {
+        throw new BaseHttpException(HttpStatus.NOT_FOUND, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/quiz-image/use-cases/get-quiz-image/get-quiz-image.handler.ts
+++ b/src/modules/quiz-image/use-cases/get-quiz-image/get-quiz-image.handler.ts
@@ -1,0 +1,31 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { QuizImageNotFoundError } from '@module/quiz-image/errors/quiz-image-not-found.error';
+import {
+  QUIZ_IMAGE_REPOSITORY,
+  QuizImageRepositoryPort,
+} from '@module/quiz-image/repositories/quiz-image/quiz-image.repository.port';
+import { GetQuizImageQuery } from '@module/quiz-image/use-cases/get-quiz-image/get-quiz-image.query';
+
+@QueryHandler(GetQuizImageQuery)
+export class GetQuizImageHandler
+  implements IQueryHandler<GetQuizImageQuery, unknown>
+{
+  constructor(
+    @Inject(QUIZ_IMAGE_REPOSITORY)
+    private readonly quizImageRepository: QuizImageRepositoryPort,
+  ) {}
+
+  async execute(query: GetQuizImageQuery): Promise<unknown> {
+    const quizImage = await this.quizImageRepository.findOneById(
+      query.quizImageId,
+    );
+
+    if (quizImage === undefined) {
+      throw new QuizImageNotFoundError();
+    }
+
+    return quizImage;
+  }
+}

--- a/src/modules/quiz-image/use-cases/get-quiz-image/get-quiz-image.module.ts
+++ b/src/modules/quiz-image/use-cases/get-quiz-image/get-quiz-image.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { QuizImageRepositoryModule } from '@module/quiz-image/repositories/quiz-image/quiz-image.repository.module';
+import { GetQuizImageController } from '@module/quiz-image/use-cases/get-quiz-image/get-quiz-image.controller';
+import { GetQuizImageHandler } from '@module/quiz-image/use-cases/get-quiz-image/get-quiz-image.handler';
+
+@Module({
+  imports: [QuizImageRepositoryModule],
+  controllers: [GetQuizImageController],
+  providers: [GetQuizImageHandler],
+})
+export class GetQuizImageModule {}

--- a/src/modules/quiz-image/use-cases/get-quiz-image/get-quiz-image.query.ts
+++ b/src/modules/quiz-image/use-cases/get-quiz-image/get-quiz-image.query.ts
@@ -1,0 +1,13 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export interface IGetQuizImageQueryProps {
+  quizImageId: string;
+}
+
+export class GetQuizImageQuery implements IQuery {
+  readonly quizImageId: string;
+
+  constructor(props: IGetQuizImageQueryProps) {
+    this.quizImageId = props.quizImageId;
+  }
+}


### PR DESCRIPTION
### Short description

퀴즈 이미지 단일 조회 어드민 API

### Proposed changes

- 퀴즈 이미지 단일 조회 어드민 API 추가

### How to test (Optional)

```bash
curl -X 'GET' \
  'http://localhost:3000/admin/quiz-images/76946711580317625' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NTgyMDcxMTYxNDQ3OTMyNTAiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NTkxMzE2NDcsImV4cCI6MTc5MDY4OTI0NywiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.6BfML2_yiZOiySmrfeAxua-KPLRihqfOAf8OBoVMawg'
```

### Reference (Optional)

Closes #134
