### PR TITLE
퀴즈의 이미지 url 대신 이미지 filename만 저장하도록 변경

### DIFF
--- a/prisma/migrations/20251025091050_quiz_image_url_to_file_name/migration.sql
+++ b/prisma/migrations/20251025091050_quiz_image_url_to_file_name/migration.sql
@@ -1,0 +1,7 @@
+-- 1️⃣ 컬럼 이름 변경
+ALTER TABLE "quiz" RENAME COLUMN "imageUrl" TO "imageFileName";
+
+-- 2️⃣ 기존 데이터에서 filename만 남기도록 업데이트
+UPDATE "quiz"
+SET "imageFileName" = regexp_replace("imageFileName", '.*/', '')
+WHERE "imageFileName" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,10 +146,10 @@ model GameRoomEventStore {
 model Quiz {
   id BigInt @id
 
-  type     String
-  answer   String
-  imageUrl String?
-  question String?
+  type          String
+  answer        String
+  imageFileName String?
+  question      String?
 
   createdAt DateTime @default(now()) @db.Timestamp(3)
   updatedAt DateTime @updatedAt @db.Timestamp(3)

--- a/src/modules/quiz/entities/__spec__/quiz.factory.ts
+++ b/src/modules/quiz/entities/__spec__/quiz.factory.ts
@@ -11,7 +11,7 @@ export const QuizFactory = Factory.define<Quiz & QuizProps>(Quiz.name)
     type: () => faker.string.nanoid(),
     question: () => faker.lorem.sentence(),
     answer: () => faker.lorem.word(),
-    imageUrl: () => faker.internet.url(),
+    imageFileName: () => faker.internet.url(),
     createdAt: () => new Date(),
     updatedAt: () => new Date(),
   })

--- a/src/modules/quiz/entities/quiz.entity.ts
+++ b/src/modules/quiz/entities/quiz.entity.ts
@@ -12,21 +12,21 @@ export interface QuizProps {
   type: string;
   question?: string | null;
   answer: string;
-  imageUrl?: string | null;
+  imageFileName?: string | null;
 }
 
 interface CreateQuizProps {
   type: string;
   question?: string | null;
   answer: string;
-  imageUrl?: string | null;
+  imageFileName?: string | null;
 }
 
 interface UpdateQuizProps {
   type?: string;
   question?: string | null;
   answer?: string;
-  imageUrl?: string | null;
+  imageFileName?: string | null;
 }
 
 export class Quiz extends AggregateRoot<QuizProps> {
@@ -46,7 +46,7 @@ export class Quiz extends AggregateRoot<QuizProps> {
         type: props.type,
         question: props.question,
         answer: props.answer,
-        imageUrl: props.imageUrl,
+        imageFileName: props.imageFileName,
       },
     });
 
@@ -56,7 +56,7 @@ export class Quiz extends AggregateRoot<QuizProps> {
         type: props.type,
         question: props.question,
         answer: props.answer,
-        imageUrl: props.imageUrl,
+        imageFileName: props.imageFileName,
       }),
     );
 
@@ -75,8 +75,18 @@ export class Quiz extends AggregateRoot<QuizProps> {
     return this.props.answer;
   }
 
+  get imageFileName(): string | undefined | null {
+    return this.props.imageFileName;
+  }
+
   get imageUrl(): string | undefined | null {
-    return this.props.imageUrl;
+    return (
+      process.env.AWS_S3_URL +
+      '/' +
+      process.env.AWS_S3_QUIZ_IMAGE_FILE_PATH +
+      '/' +
+      this.props.imageFileName
+    );
   }
 
   /**
@@ -95,8 +105,8 @@ export class Quiz extends AggregateRoot<QuizProps> {
       this.props.answer = props.answer;
     }
 
-    if (props.imageUrl !== undefined) {
-      this.props.imageUrl = props.imageUrl;
+    if (props.imageFileName !== undefined) {
+      this.props.imageFileName = props.imageFileName;
     }
 
     this.apply(
@@ -105,7 +115,7 @@ export class Quiz extends AggregateRoot<QuizProps> {
         type: this.props.type,
         question: this.props.question,
         answer: this.props.answer,
-        imageUrl: this.props.imageUrl,
+        imageFileName: this.props.imageFileName,
       }),
     );
   }

--- a/src/modules/quiz/events/quiz-created.event.ts
+++ b/src/modules/quiz/events/quiz-created.event.ts
@@ -5,7 +5,7 @@ interface QuizCreatedEventPayload {
   type: string;
   question?: string | null;
   answer: string;
-  imageUrl?: string | null;
+  imageFileName?: string | null;
 }
 
 export class QuizCreatedEvent extends DomainEvent<QuizCreatedEventPayload> {

--- a/src/modules/quiz/events/quiz-updated.event.ts
+++ b/src/modules/quiz/events/quiz-updated.event.ts
@@ -5,7 +5,7 @@ interface QuizUpdatedEventPayload {
   type?: string;
   question?: string | null;
   answer?: string;
-  imageUrl?: string | null;
+  imageFileName?: string | null;
 }
 
 export class QuizUpdatedEvent extends DomainEvent<QuizUpdatedEventPayload> {

--- a/src/modules/quiz/mappers/quiz.mapper.ts
+++ b/src/modules/quiz/mappers/quiz.mapper.ts
@@ -13,7 +13,7 @@ export class QuizMapper extends BaseMapper {
         type: raw.type,
         answer: raw.answer,
         question: raw.question ?? undefined,
-        imageUrl: raw.imageUrl ?? undefined,
+        imageFileName: raw.imageFileName ?? undefined,
       },
     });
   }
@@ -26,7 +26,7 @@ export class QuizMapper extends BaseMapper {
       type: entity.type,
       answer: entity.answer,
       question: entity.question ?? null,
-      imageUrl: entity.imageUrl ?? null,
+      imageFileName: entity.imageFileName ?? null,
     };
   }
 }

--- a/src/modules/quiz/use-cases/create-quizzes/create-quizzes.handler.ts
+++ b/src/modules/quiz/use-cases/create-quizzes/create-quizzes.handler.ts
@@ -72,7 +72,7 @@ export class CreateQuizzesHandler
           type: item.type,
           answer: item.answer,
           question: item.question,
-          imageUrl: item.imageUrl,
+          imageFileName: this.extractFileNameFromUrl(item.imageUrl as string),
         }),
       );
 

--- a/src/modules/quiz/use-cases/update-quiz/__spec__/update-quiz.handler.spec.ts
+++ b/src/modules/quiz/use-cases/update-quiz/__spec__/update-quiz.handler.spec.ts
@@ -86,7 +86,7 @@ describe(UpdateQuizHandler.name, () => {
           type: command.type,
           question: command.question,
           answer: command.answer,
-          imageUrl: command.imageUrl,
+          imageFileName: expect.any(String),
         }),
       );
     });

--- a/src/modules/quiz/use-cases/update-quiz/update-quiz.handler.ts
+++ b/src/modules/quiz/use-cases/update-quiz/update-quiz.handler.ts
@@ -52,7 +52,7 @@ export class UpdateQuizHandler
       type: command.type,
       question: command.question,
       answer: command.answer,
-      imageUrl: command.imageUrl,
+      imageFileName: command.imageUrl?.split('/').pop() as string,
     });
 
     await this.quizRepository.update(quiz);


### PR DESCRIPTION
### Short description

퀴즈의 이미지 url 대신 이미지 filename만 저장하도록 변경

### Proposed changes

- 퀴즈 이미지 file path를 환경변수를 사용하도록 변경
- 데이터베이스에 컬럼 이름을 url에서 fileName로 변경
- 데이터베이스 url to fileName 마이그레이션
- 퀴즈 생성 시 fileName을 저장하도록 변경
- 퀴즈 수정 시 fileName을 저장하도록 변경

### How to test (Optional)

퀴즈 생성 및 수정 후 데이터베이스에 파일네임만 저장하는지 확인

#### 퀴즈 생성

```bash
curl -X 'PUT' \
  'http://localhost:3000/admin/quizzes' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3Njk4NTIwMTAxOTAxNDU1NjIiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NjEzODM4NTgsImV4cCI6MTc5Mjk0MTQ1OCwiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.NkakPioS1MtolHbaXA3MX8y8M0_pzpQ3fOqkOkz1wRk' \
  -H 'Content-Type: application/json' \
  -d '[
  {
    "type": "string",
    "answer": "string",
    "question": "string",
    "imageUrl": "https://dev-zoop.s3.ap-northeast-2.amazonaws.com/quiz-images/769462658834457294.png"
  }
]'
```

#### 퀴즈 수정

```bash
curl -X 'PATCH' \
  'http://localhost:3000/admin/quizzes/770210245215923802' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3Njk4NTIwMTAxOTAxNDU1NjIiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NjEzODM4NTgsImV4cCI6MTc5Mjk0MTQ1OCwiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.NkakPioS1MtolHbaXA3MX8y8M0_pzpQ3fOqkOkz1wRk' \
  -H 'Content-Type: application/json' \
  -d '{
  "type": "string",
  "answer": "string",
  "question": "string",
  "imageUrl": "https://dev-zoop.s3.ap-northeast-2.amazonaws.com/quiz-images/769467520775247066.png"
}'
```

### Reference (Optional)

Closes #147 
