### PR TITLE
클라이언트에게 쿠키로 전달한 엑세스 토큰을 authorization header로 다시 전송할 수 없는 문제 수정

### DIFF
--- a/src/modules/auth/use-cases/sign-in-with-google/sign-in-with-google.controller.ts
+++ b/src/modules/auth/use-cases/sign-in-with-google/sign-in-with-google.controller.ts
@@ -46,7 +46,7 @@ export class SignInWithGoogleController {
   @ApiOkResponse({
     headers: {
       'Set-Cookie': {
-        description: 'access_token=token; Path=/; HttpOnly',
+        description: 'access_token=token;',
         schema: {
           type: 'string',
         },
@@ -80,9 +80,7 @@ export class SignInWithGoogleController {
       AuthToken
     >(command);
 
-    res.cookie('access_token', authToken.accessToken, {
-      httpOnly: true,
-    });
+    res.cookie('access_token', authToken.accessToken, {});
 
     const state = JSON.parse(req.query.state);
 

--- a/src/modules/auth/use-cases/sign-in-with-username/sign-in-with-username.controller.ts
+++ b/src/modules/auth/use-cases/sign-in-with-username/sign-in-with-username.controller.ts
@@ -28,7 +28,7 @@ export class SignInWithUsernameController {
     type: AuthTokenDto,
     headers: {
       'Set-Cookie': {
-        description: 'access_token=token; Path=/; HttpOnly',
+        description: 'access_token=token;',
         schema: {
           type: 'string',
         },
@@ -55,9 +55,7 @@ export class SignInWithUsernameController {
         AuthToken
       >(command);
 
-      res.cookie('access_token', authToken.accessToken, {
-        httpOnly: true,
-      });
+      res.cookie('access_token', authToken.accessToken, {});
 
       return AuthTokenDtoAssembler.convertToDto(authToken);
     } catch (error) {

--- a/src/modules/auth/use-cases/sign-up-with-username/sign-up-with-username.controller.ts
+++ b/src/modules/auth/use-cases/sign-up-with-username/sign-up-with-username.controller.ts
@@ -28,7 +28,7 @@ export class SignUpWithUsernameController {
     type: AuthTokenDto,
     headers: {
       'Set-Cookie': {
-        description: 'access_token=token; Path=/; HttpOnly',
+        description: 'access_token=token;',
         schema: {
           type: 'string',
         },
@@ -55,9 +55,7 @@ export class SignUpWithUsernameController {
         AuthToken
       >(command);
 
-      res.cookie('access_token', authToken.accessToken, {
-        httpOnly: true,
-      });
+      res.cookie('access_token', authToken.accessToken, {});
 
       return AuthTokenDtoAssembler.convertToDto(authToken);
     } catch (error) {


### PR DESCRIPTION
### Short description

access-token을 쿠키에 담을 때 http only 픞래그를 설정했지만
인증을 위해서는 authorization header로 access token을 받음
때문에 프론트엔드에서는 cookie에 접근할 수 없기 때문에 http only 플래그를 제거 당장에 조치일 뿐이고 운영 배포 전 인증 프로토콜에 대한 정의를 추가로 할 예정

### Proposed changes

아래 유즈케이스 쿠키 플래그의 http only 제거

- username 로그인
- username 회원가입
- google 소셜 로그인

### How to test (Optional)

유저네임 회원가입 응답의 쿠키 설정 확인

```bash
curl --location 'http://localhost:3000/auth/sign-up/username' \
--header 'Content-Type: application/json' \
--header 'Cookie: access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3NzE2NTUzMDQ2NDcyNTM2NTciLCJyb2xlIjoidXNlciIsImlhdCI6MTc2MTgxMzc2MSwiZXhwIjoxNzkzMzcxMzYxLCJpc3MiOiJxdWl6emVzX2dhbWVfaW9fYmFja2VuZCJ9.kOlGJOuoeMMpoL2KqlIydxntkKWJk9yapK-MPA1tkBo' \
--data '{
    "username": "user1",
    "password": "password1"
}'
```

<img width="857" height="544" alt="image" src="https://github.com/user-attachments/assets/417a9e90-2b93-43bc-bf0c-d36adc00bb76" />


### Reference (Optional)

Closes #153
