### PR TITLE
퀴즈 이미지 도메인 응답으로 quizImageFileName 추가

### DIFF
--- a/src/modules/quiz-image/assemblers/quiz-image-dto.assembler.ts
+++ b/src/modules/quiz-image/assemblers/quiz-image-dto.assembler.ts
@@ -14,6 +14,7 @@ export class QuizImageDtoAssembler {
     dto.category = quizImage.category;
     dto.name = quizImage.name;
     dto.originalFileName = quizImage.originalFileName;
+    dto.quizImageFileName = quizImage.fileName;
     dto.quizImageUrl = AssetUrlManager.fileNameToUrl(
       quizImage.fileName,
       'quizImage',

--- a/src/modules/quiz-image/dto/quiz-image.dto.ts
+++ b/src/modules/quiz-image/dto/quiz-image.dto.ts
@@ -13,6 +13,9 @@ export class QuizImageDto extends BaseResponseDto {
   originalFileName: string;
 
   @ApiProperty()
+  quizImageFileName: string;
+
+  @ApiProperty()
   quizImageUrl: string;
 
   @ApiProperty()


### PR DESCRIPTION
### Short description

퀴즈 이미지 도메인 응답으로 quizImageFileName 추가

### Proposed changes

- 퀴즈 이미지 도메인 응답으로 quizImageFileName 추가

### How to test (Optional)

```bash
curl -X 'GET' \
  'http://localhost:4000/admin/quiz-images?perPage=20&sort=createdAt%3Aasc' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3Njk4NTIwMTAxOTAxNDU1NjIiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NjIxNDgyMDAsImV4cCI6MTc5MzcwNTgwMCwiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.ZSlmPBBjGNO8tvdTAeO7SNfbh9BdISySqLvxtiOj4wo'
```

### Reference (Optional)

Closes #158 
