### PR TITLE
퀴즈 이미지 생성 시 contentType을 저장하도록 변경

### DIFF
--- a/prisma/migrations/20251105052347_quiz_image_content_type/migration.sql
+++ b/prisma/migrations/20251105052347_quiz_image_content_type/migration.sql
@@ -1,0 +1,14 @@
+-- 1. NULL 허용으로 contentType 컬럼 추가
+ALTER TABLE "quiz_image"
+ADD COLUMN "contentType" TEXT;
+
+-- 2. 기존 row 중 contentType이 NULL인 경우
+--    extension='png' → contentType='image/png'
+UPDATE "quiz_image"
+SET "contentType" = CONCAT('image/', "extension")
+WHERE "contentType" IS NULL;
+
+-- 3. 이제 NOT NULL 제약 추가
+ALTER TABLE "quiz_image"
+ALTER COLUMN "contentType"
+SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,6 +179,7 @@ model QuizImage {
   category         String
   extension        String
   contentLength    String
+  contentType      String
   width            Int
   height           Int
 

--- a/src/modules/quiz-image/entities/__spec__/quiz-image.factory.ts
+++ b/src/modules/quiz-image/entities/__spec__/quiz-image.factory.ts
@@ -19,6 +19,7 @@ export const QuizImageFactory = Factory.define<QuizImage & QuizImageProps>(
     fileName: () => faker.string.nanoid(),
     extension: () => faker.word.verb(),
     contentLength: () => faker.string.numeric(),
+    contentType: () => faker.system.mimeType(),
     width: () => faker.number.int({ min: 100, max: 1000 }),
     height: () => faker.number.int({ min: 100, max: 1000 }),
     createdAt: () => new Date(),

--- a/src/modules/quiz-image/entities/quiz-image.entity.ts
+++ b/src/modules/quiz-image/entities/quiz-image.entity.ts
@@ -17,6 +17,7 @@ export interface QuizImageProps {
   fileName: string;
   extension: string;
   contentLength: string;
+  contentType: string;
   width: number;
   height: number;
 }
@@ -27,6 +28,7 @@ interface CreateQuizImageProps {
   originalFileName: string;
   extension: string;
   contentLength: string;
+  contentType: string;
   width: number;
   height: number;
 }
@@ -54,6 +56,7 @@ export class QuizImage extends AggregateRoot<QuizImageProps> {
         fileName: `${TSID.create().number.toString()}.${props.extension}`,
         extension: props.extension,
         contentLength: props.contentLength,
+        contentType: props.contentType,
         width: props.width,
         height: props.height,
       },
@@ -69,6 +72,7 @@ export class QuizImage extends AggregateRoot<QuizImageProps> {
         fileName: quizImage.props.fileName,
         extension: quizImage.props.extension,
         contentLength: quizImage.props.contentLength,
+        contentType: quizImage.props.contentType,
         width: quizImage.props.width,
         height: quizImage.props.height,
       }),
@@ -98,7 +102,7 @@ export class QuizImage extends AggregateRoot<QuizImageProps> {
   }
 
   get contentType(): string {
-    return `image/${this.props.extension}`;
+    return this.props.contentType;
   }
 
   get contentLength(): string {

--- a/src/modules/quiz-image/events/quiz-image-created.event.ts
+++ b/src/modules/quiz-image/events/quiz-image-created.event.ts
@@ -7,6 +7,7 @@ interface QuizImageCreatedEventPayload {
   fileName: string;
   extension: string;
   contentLength: string;
+  contentType: string;
   width: number;
   height: number;
 }

--- a/src/modules/quiz-image/mappers/quiz-image.mapper.ts
+++ b/src/modules/quiz-image/mappers/quiz-image.mapper.ts
@@ -16,6 +16,7 @@ export class QuizImageMapper extends BaseMapper {
         fileName: raw.fileName,
         extension: raw.extension,
         contentLength: raw.contentLength,
+        contentType: raw.contentType,
         width: raw.width,
         height: raw.height,
       },
@@ -33,6 +34,7 @@ export class QuizImageMapper extends BaseMapper {
       fileName: entity.fileName,
       extension: entity.extension,
       contentLength: entity.contentLength,
+      contentType: entity.contentType,
       width: entity.width,
       height: entity.height,
     };

--- a/src/modules/quiz-image/use-cases/create-quiz-image/__spec__/create-quiz-image-command.factory.ts
+++ b/src/modules/quiz-image/use-cases/create-quiz-image/__spec__/create-quiz-image-command.factory.ts
@@ -14,6 +14,7 @@ export const CreateQuizImageCommandFactory =
     originalFileName: () => faker.string.nanoid(),
     extension: () => faker.word.verb(),
     contentLength: () => faker.string.numeric(),
+    contentType: () => faker.system.mimeType(),
     width: () => faker.number.int({ min: 100, max: 1000 }),
     height: () => faker.number.int({ min: 100, max: 1000 }),
   });

--- a/src/modules/quiz-image/use-cases/create-quiz-image/__spec__/create-quiz-image.handler.spec.ts
+++ b/src/modules/quiz-image/use-cases/create-quiz-image/__spec__/create-quiz-image.handler.spec.ts
@@ -74,6 +74,7 @@ describe(CreateQuizImageHandler.name, () => {
         category: command.category,
         extension: command.extension,
         contentLength: command.contentLength,
+        contentType: command.contentType,
         width: command.width,
         height: command.height,
       });

--- a/src/modules/quiz-image/use-cases/create-quiz-image/create-quiz-image.command.ts
+++ b/src/modules/quiz-image/use-cases/create-quiz-image/create-quiz-image.command.ts
@@ -7,6 +7,7 @@ export interface ICreateQuizImageCommandProps {
   originalFileName: string;
   extension: string;
   contentLength: string;
+  contentType: string;
   width: number;
   height: number;
 }
@@ -18,6 +19,7 @@ export class CreateQuizImageCommand implements ICommand {
   readonly originalFileName: string;
   readonly extension: string;
   readonly contentLength: string;
+  readonly contentType: string;
   readonly width: number;
   readonly height: number;
 
@@ -28,6 +30,7 @@ export class CreateQuizImageCommand implements ICommand {
     this.originalFileName = props.originalFileName;
     this.extension = props.extension;
     this.contentLength = props.contentLength;
+    this.contentType = props.contentType;
     this.width = props.width;
     this.height = props.height;
   }

--- a/src/modules/quiz-image/use-cases/create-quiz-image/create-quiz-image.controller.ts
+++ b/src/modules/quiz-image/use-cases/create-quiz-image/create-quiz-image.controller.ts
@@ -60,6 +60,7 @@ export class CreateQuizImageController {
       height: quizImageDimensions.height,
       extension: quizImageDimensions.type as string,
       contentLength: String(dto.file.size),
+      contentType: dto.file.mimeType,
     });
 
     const quizImage = await this.commandBus.execute<

--- a/src/modules/quiz-image/use-cases/create-quiz-image/create-quiz-image.handler.ts
+++ b/src/modules/quiz-image/use-cases/create-quiz-image/create-quiz-image.handler.ts
@@ -40,6 +40,7 @@ export class CreateQuizImageHandler
       originalFileName: command.originalFileName,
       extension: command.extension,
       contentLength: command.contentLength,
+      contentType: command.contentType,
       width: command.width,
       height: command.height,
     });


### PR DESCRIPTION
### Short description

퀴즈 이미지 생성 시 contentType을 저장하도록 변경

### Proposed changes

- 퀴즈 이미지 생성 시 contentType을 저장하도록 변경
   - DB 스키마 변경
   - 기존에 contentType이 존재하지 않는 컬럼에 대해서 image/{{extension}}으로 마이그레이션

### How to test (Optional)

```bash
curl -X 'POST' \
  'http://localhost:4000/admin/quiz-images' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3Njk4NTIwMTAxOTAxNDU1NjIiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NjIzMTYwOTksImV4cCI6MTc5Mzg3MzY5OSwiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.sUrW4K1pN5GNGr_tBRmIo1XC7njkIjzTq29yj9UOVX4' \
  -H 'Content-Type: multipart/form-data' \
  -F 'file=@765488804233833793 (2).png;type=image/png' \
  -F 'category=string' \
  -F 'name=originalFIleName의 확장자를 제외함'
```

### Reference (Optional)

Closes #196 
