### PR TITLE
퀴즈 목록 조회 시 이미지 파일명으로 필터링 기능 추가

### DIFF
--- a/prisma/migrations/20251105055055_quiz_index_image_file_name/migration.sql
+++ b/prisma/migrations/20251105055055_quiz_index_image_file_name/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "quiz_imageFileName_idx" ON "quiz"("imageFileName");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -154,6 +154,7 @@ model Quiz {
   createdAt DateTime @default(now()) @db.Timestamp(3)
   updatedAt DateTime @updatedAt @db.Timestamp(3)
 
+  @@index([imageFileName])
   @@map("quiz")
 }
 

--- a/src/modules/quiz/repositories/quiz/__spec__/quiz.repository.spec.ts
+++ b/src/modules/quiz/repositories/quiz/__spec__/quiz.repository.spec.ts
@@ -80,9 +80,25 @@ describe(QuizRepository, () => {
 
     describe('모든 퀴즈 목록을 조회하면', () => {
       it('모든 퀴즈 목록을 반환해야 한다.', async () => {
-        await expect(repository.findAll()).resolves.toEqual(
+        await expect(repository.findAll({})).resolves.toEqual(
           expect.arrayContaining(quizzes),
         );
+      });
+    });
+
+    describe('이미지 파일명으로 필터링하면', () => {
+      let targetQuiz: Quiz;
+
+      beforeEach(() => {
+        targetQuiz = quizzes[0];
+      });
+
+      it('해당 이미지 파일명을 가진 퀴즈 목록을 반환해야 한다.', async () => {
+        await expect(
+          repository.findAll({
+            filter: { imageFileName: targetQuiz.imageFileName as string },
+          }),
+        ).resolves.toEqual(expect.arrayContaining([targetQuiz]));
       });
     });
   });

--- a/src/modules/quiz/repositories/quiz/quiz.repository.port.ts
+++ b/src/modules/quiz/repositories/quiz/quiz.repository.port.ts
@@ -8,13 +8,15 @@ export const QUIZ_REPOSITORY = Symbol('QUIZ_REPOSITORY');
 
 export interface QuizRaw extends QuizModel {}
 
-export interface QuizFilter {}
+export interface QuizFilter {
+  imageFileName?: string;
+}
 
 export interface QuizOrder extends ISort<'createdAt'> {}
 
 export interface QuizRepositoryPort
   extends RepositoryPort<Quiz, QuizFilter, QuizOrder> {
   insertMany(quizzes: Quiz[]): Promise<void>;
-  findAll(): Promise<Quiz[]>;
+  findAll(params: { filter?: QuizFilter }): Promise<Quiz[]>;
   findManyByFileNames(fileNames: Set<string>): Promise<Quiz[]>;
 }

--- a/src/modules/quiz/repositories/quiz/quiz.repository.ts
+++ b/src/modules/quiz/repositories/quiz/quiz.repository.ts
@@ -5,6 +5,7 @@ import {
   TransactionHost,
 } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { Prisma } from '@prisma/client';
 
 import { Quiz } from '@module/quiz/entities/quiz.entity';
 import { QuizMapper } from '@module/quiz/mappers/quiz.mapper';
@@ -41,8 +42,16 @@ export class QuizRepository
     });
   }
 
-  async findAll(): Promise<Quiz[]> {
-    const quizzes = await this.txHost.tx.quiz.findMany();
+  async findAll(params: { filter: QuizFilter }): Promise<Quiz[]> {
+    const where: Prisma.QuizWhereInput = {};
+
+    if (params.filter?.imageFileName !== undefined) {
+      where.imageFileName = params.filter.imageFileName;
+    }
+
+    const quizzes = await this.txHost.tx.quiz.findMany({
+      where,
+    });
 
     return quizzes.map((quiz) => this.mapper.toEntity(quiz));
   }

--- a/src/modules/quiz/use-cases/list-quizzes/__spec__/list-quizzes-query.factory.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/__spec__/list-quizzes-query.factory.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { Factory } from 'rosie';
 
 import { ListQuizzesQuery } from '@module/quiz/use-cases/list-quizzes/list-quizzes.query';
@@ -5,4 +6,6 @@ import { ListQuizzesQuery } from '@module/quiz/use-cases/list-quizzes/list-quizz
 export const ListQuizzesQueryFactory = Factory.define<ListQuizzesQuery>(
   ListQuizzesQuery.name,
   ListQuizzesQuery,
-).attrs({});
+).attrs({
+  imageFileName: () => faker.string.nanoid(),
+});

--- a/src/modules/quiz/use-cases/list-quizzes/__spec__/list-quizzes.handler.spec.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/__spec__/list-quizzes.handler.spec.ts
@@ -32,7 +32,7 @@ describe(ListQuizzesHandler.name, () => {
   });
 
   beforeEach(() => {
-    query = ListQuizzesQueryFactory.build({ type: undefined });
+    query = ListQuizzesQueryFactory.build({ imageFileName: undefined });
   });
 
   beforeEach(async () => {

--- a/src/modules/quiz/use-cases/list-quizzes/list-quizzes.controller.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/list-quizzes.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpStatus, UseGuards } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Query, UseGuards } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 import {
   ApiBearerAuth,
@@ -11,6 +11,7 @@ import { JwtAuthGuard } from '@module/auth/jwt/jwt-auth.guard';
 import { QuizCollectionDtoAssembler } from '@module/quiz/assemblers/quiz-collection-dto.assembler';
 import { QuizCollectionAdminDto } from '@module/quiz/dto/quiz-collection.admin-dto';
 import { Quiz } from '@module/quiz/entities/quiz.entity';
+import { ListQuizzesDto } from '@module/quiz/use-cases/list-quizzes/list-quizzes.dto';
 import { ListQuizzesQuery } from '@module/quiz/use-cases/list-quizzes/list-quizzes.query';
 
 import {
@@ -36,8 +37,12 @@ export class ListQuizzesController {
   @ApiOkResponse({ type: QuizCollectionAdminDto })
   @UseGuards(JwtAuthGuard, AdminGuard)
   @Get('admin/quizzes')
-  async listQuizzes(): Promise<QuizCollectionAdminDto> {
-    const query = new ListQuizzesQuery({});
+  async listQuizzes(
+    @Query() dto: ListQuizzesDto,
+  ): Promise<QuizCollectionAdminDto> {
+    const query = new ListQuizzesQuery({
+      imageFileName: dto.imageFileName,
+    });
 
     const quizzes = await this.queryBus.execute<ListQuizzesQuery, Quiz[]>(
       query,

--- a/src/modules/quiz/use-cases/list-quizzes/list-quizzes.dto.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/list-quizzes.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsOptional, IsString } from 'class-validator';
+
+export class ListQuizzesDto {
+  @ApiProperty({
+    description: '이미지 파일 이름으로 필터링',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  imageFileName?: string;
+}

--- a/src/modules/quiz/use-cases/list-quizzes/list-quizzes.handler.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/list-quizzes.handler.ts
@@ -17,8 +17,9 @@ export class ListQuizzesHandler
     private readonly quizRepository: QuizRepositoryPort,
   ) {}
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(query: ListQuizzesQuery): Promise<Quiz[]> {
-    return await this.quizRepository.findAll();
+    return await this.quizRepository.findAll({
+      filter: { imageFileName: query.imageFileName },
+    });
   }
 }

--- a/src/modules/quiz/use-cases/list-quizzes/list-quizzes.query.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/list-quizzes.query.ts
@@ -1,8 +1,13 @@
 import { IQuery } from '@nestjs/cqrs';
 
-export interface IListQuizzesQueryProps {}
+export interface IListQuizzesQueryProps {
+  imageFileName?: string;
+}
 
 export class ListQuizzesQuery implements IQuery {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  constructor(props: IListQuizzesQueryProps) {}
+  readonly imageFileName?: string;
+
+  constructor(props: IListQuizzesQueryProps) {
+    this.imageFileName = props.imageFileName;
+  }
 }


### PR DESCRIPTION
### Short description

퀴즈 목록 조회 시 이미지 파일명으로 필터링 기능 추가

### Proposed changes

- 퀴즈 목록 조회 시 이미지 파일명으로 필터링 기능 추가
   - 퀴즈 스키마에 이미지 파일명 필드를 인덱스로 추가

### How to test (Optional)

```bash
curl -X 'GET' \
  'http://localhost:4000/admin/quizzes' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3Njk4NTIwMTAxOTAxNDU1NjIiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NjIzMTYwOTksImV4cCI6MTc5Mzg3MzY5OSwiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.sUrW4K1pN5GNGr_tBRmIo1XC7njkIjzTq29yj9UOVX4'
```

### Reference (Optional)

Closes #159 
