### PR TITLE
아바타 단일 조회 ADMIN API

### DIFF
--- a/src/modules/avatar/avatar.module.ts
+++ b/src/modules/avatar/avatar.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
 
 import { CreateAvatarModule } from '@module/avatar/use-cases/create-avatar/create-avatar.module';
+import { GetAvatarModule } from '@module/avatar/use-cases/get-avatar/get-avatar.module';
 import { ListAvatarsModule } from '@module/avatar/use-cases/list-avatars/list-avatars.module';
 import { UpdateAvatarModule } from '@module/avatar/use-cases/update-avatar/update-avatar.module';
 
 @Module({
-  imports: [CreateAvatarModule, ListAvatarsModule, UpdateAvatarModule],
+  imports: [
+    CreateAvatarModule,
+    GetAvatarModule,
+    ListAvatarsModule,
+    UpdateAvatarModule,
+  ],
 })
 export class AvatarModule {}

--- a/src/modules/avatar/use-cases/get-avatar/__spec__/get-avatar-query.factory.ts
+++ b/src/modules/avatar/use-cases/get-avatar/__spec__/get-avatar-query.factory.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'rosie';
+
+import { GetAvatarQuery } from '@module/avatar/use-cases/get-avatar/get-avatar.query';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+export const GetAvatarQueryFactory = Factory.define<GetAvatarQuery>(
+  GetAvatarQuery.name,
+  GetAvatarQuery,
+).attrs({
+  avatarId: () => generateEntityId(),
+});

--- a/src/modules/avatar/use-cases/get-avatar/__spec__/get-avatar.handler.spec.ts
+++ b/src/modules/avatar/use-cases/get-avatar/__spec__/get-avatar.handler.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AvatarFactory } from '@module/avatar/entities/__spec__/avatar.factory';
+import { Avatar } from '@module/avatar/entities/avatar.entity';
+import { AvatarNotFoundError } from '@module/avatar/errors/avatar-not-found.error';
+import { AvatarRepositoryModule } from '@module/avatar/repositories/avatar/avatar.repository.module';
+import {
+  AVATAR_REPOSITORY,
+  AvatarRepositoryPort,
+} from '@module/avatar/repositories/avatar/avatar.repository.port';
+import { GetAvatarQueryFactory } from '@module/avatar/use-cases/get-avatar/__spec__/get-avatar-query.factory';
+import { GetAvatarHandler } from '@module/avatar/use-cases/get-avatar/get-avatar.handler';
+import { GetAvatarQuery } from '@module/avatar/use-cases/get-avatar/get-avatar.query';
+
+import { ClsModuleFactory } from '@common/factories/cls-module.factory';
+
+describe(GetAvatarHandler.name, () => {
+  let handler: GetAvatarHandler;
+
+  let avatarRepository: AvatarRepositoryPort;
+
+  let query: GetAvatarQuery;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ClsModuleFactory(), AvatarRepositoryModule],
+      providers: [GetAvatarHandler],
+    }).compile();
+
+    handler = module.get<GetAvatarHandler>(GetAvatarHandler);
+
+    avatarRepository = module.get<AvatarRepositoryPort>(AVATAR_REPOSITORY);
+  });
+
+  beforeEach(() => {
+    query = GetAvatarQueryFactory.build();
+  });
+
+  describe('아바타를 조회하면', () => {
+    let avatar: Avatar;
+
+    beforeEach(async () => {
+      avatar = await avatarRepository.insert(
+        AvatarFactory.build({ id: query.avatarId }),
+      );
+    });
+
+    it('아바타를 반환해야한다.', async () => {
+      await expect(handler.execute(query)).resolves.toEqual(avatar);
+    });
+  });
+
+  describe('식별자에 해당하는 아바타가 존재하지 않는 경우', () => {
+    it('아바타를 찾을 수 없는 에러가 발생해야한다.', async () => {
+      await expect(handler.execute(query)).rejects.toThrow(AvatarNotFoundError);
+    });
+  });
+});

--- a/src/modules/avatar/use-cases/get-avatar/get-avatar.controller.ts
+++ b/src/modules/avatar/use-cases/get-avatar/get-avatar.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, HttpStatus, Param } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { AvatarDtoAssembler } from '@module/avatar/assemblers/avatar-dto.assembler';
+import { AvatarAdminDto } from '@module/avatar/dto/avatar.admin-dto';
+import { Avatar } from '@module/avatar/entities/avatar.entity';
+import { AvatarNotFoundError } from '@module/avatar/errors/avatar-not-found.error';
+import { GetAvatarQuery } from '@module/avatar/use-cases/get-avatar/get-avatar.query';
+
+import { BaseHttpException } from '@common/base/base-http-exception';
+import {
+  PermissionDeniedError,
+  RequestValidationError,
+  UnauthorizedError,
+} from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import { ParsePositiveIntStringPipe } from '@common/pipes/positive-int-string.pipe';
+
+@ApiTags('avatar')
+@Controller()
+export class GetAvatarController {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  @ApiOperation({ summary: '아바타 조회' })
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+    [HttpStatus.UNAUTHORIZED]: [UnauthorizedError],
+    [HttpStatus.FORBIDDEN]: [PermissionDeniedError],
+    [HttpStatus.NOT_FOUND]: [AvatarNotFoundError],
+  })
+  @ApiOkResponse({ type: AvatarAdminDto })
+  @Get('admin/avatars/:avatarId')
+  async getAvatar(
+    @Param('avatarId', ParsePositiveIntStringPipe) avatarId: string,
+  ): Promise<AvatarAdminDto> {
+    try {
+      const query = new GetAvatarQuery({
+        avatarId,
+      });
+
+      const avatar = await this.queryBus.execute<GetAvatarQuery, Avatar>(query);
+
+      return AvatarDtoAssembler.convertToAdminDto(avatar);
+    } catch (error) {
+      if (error instanceof AvatarNotFoundError) {
+        throw new BaseHttpException(HttpStatus.NOT_FOUND, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/avatar/use-cases/get-avatar/get-avatar.handler.ts
+++ b/src/modules/avatar/use-cases/get-avatar/get-avatar.handler.ts
@@ -1,0 +1,28 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { Avatar } from '@module/avatar/entities/avatar.entity';
+import { AvatarNotFoundError } from '@module/avatar/errors/avatar-not-found.error';
+import {
+  AVATAR_REPOSITORY,
+  AvatarRepositoryPort,
+} from '@module/avatar/repositories/avatar/avatar.repository.port';
+import { GetAvatarQuery } from '@module/avatar/use-cases/get-avatar/get-avatar.query';
+
+@QueryHandler(GetAvatarQuery)
+export class GetAvatarHandler implements IQueryHandler<GetAvatarQuery, Avatar> {
+  constructor(
+    @Inject(AVATAR_REPOSITORY)
+    private readonly avatarRepository: AvatarRepositoryPort,
+  ) {}
+
+  async execute(query: GetAvatarQuery): Promise<Avatar> {
+    const avatar = await this.avatarRepository.findOneById(query.avatarId);
+
+    if (avatar === undefined) {
+      throw new AvatarNotFoundError();
+    }
+
+    return avatar;
+  }
+}

--- a/src/modules/avatar/use-cases/get-avatar/get-avatar.module.ts
+++ b/src/modules/avatar/use-cases/get-avatar/get-avatar.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { AvatarRepositoryModule } from '@module/avatar/repositories/avatar/avatar.repository.module';
+import { GetAvatarController } from '@module/avatar/use-cases/get-avatar/get-avatar.controller';
+import { GetAvatarHandler } from '@module/avatar/use-cases/get-avatar/get-avatar.handler';
+
+@Module({
+  imports: [AvatarRepositoryModule],
+  controllers: [GetAvatarController],
+  providers: [GetAvatarHandler],
+})
+export class GetAvatarModule {}

--- a/src/modules/avatar/use-cases/get-avatar/get-avatar.query.ts
+++ b/src/modules/avatar/use-cases/get-avatar/get-avatar.query.ts
@@ -1,0 +1,13 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export interface IGetAvatarQueryProps {
+  avatarId: string;
+}
+
+export class GetAvatarQuery implements IQuery {
+  readonly avatarId: string;
+
+  constructor(props: IGetAvatarQueryProps) {
+    this.avatarId = props.avatarId;
+  }
+}


### PR DESCRIPTION
### Short description

아바타 단일 조회 ADMIN API

### Proposed changes

- 아바타 단일 조회 ADMIN API

### How to test (Optional)

```bash
curl -X 'GET' \
  'http://localhost:4000/admin/avatars/77560401436487577' \
  -H 'accept: application/json'
```

### Reference (Optional)

Closes #167
