### PR TITLE
간헐적으로 실패하는 닉네임소스 핸들러 유닛테스트 수정

### DIFF
--- a/src/modules/nickname-source/entities/__spec__/nickname-source.factory.ts
+++ b/src/modules/nickname-source/entities/__spec__/nickname-source.factory.ts
@@ -13,7 +13,7 @@ export const NicknameSourceFactory = Factory.define<
 >(NicknameSource.name)
   .attrs({
     id: () => generateEntityId(),
-    name: () => faker.string.nanoid(5),
+    name: () => faker.string.nanoid(10),
     sequence: () => 1,
     createdAt: () => new Date(),
     updatedAt: () => new Date(),

--- a/src/modules/nickname-source/use-cases/create-nickname-source/__spec__/create-nickname-source-command.factory.ts
+++ b/src/modules/nickname-source/use-cases/create-nickname-source/__spec__/create-nickname-source-command.factory.ts
@@ -8,5 +8,5 @@ export const CreateNicknameSourceCommandFactory =
     CreateNicknameSourceCommand.name,
     CreateNicknameSourceCommand,
   ).attrs({
-    name: () => faker.string.nanoid(1),
+    name: () => faker.string.nanoid(10),
   });

--- a/src/modules/nickname-source/use-cases/update-nickname-source/__spec__/update-nickname-source-command.factory.ts
+++ b/src/modules/nickname-source/use-cases/update-nickname-source/__spec__/update-nickname-source-command.factory.ts
@@ -11,5 +11,5 @@ export const UpdateNicknameSourceCommandFactory =
     UpdateNicknameSourceCommand,
   ).attrs({
     nicknameSourceId: () => generateEntityId(),
-    name: () => faker.string.nanoid(1),
+    name: () => faker.string.nanoid(10),
   });


### PR DESCRIPTION
### Short description

간헐적으로 실패하는 닉네임소스 생성 핸들러 유닛테스트 수정
name 필드는 유니크 필드임
커멘드 생성 시 nanoId(1)로 생성하기 때문에 간헐적으로 유일성이 보장되지 않아 문제가 생김

### Proposed changes

- 간헐적으로 실패하는 닉네임소스 핸들러 유닛테스트 수정

### How to test (Optional)

npm run test

### Reference (Optional)

_Resolves #issue-number_
_Closes #issue-number_
_Refs #issue-number_
