### PR TITLE
아바타 삭제 ADMIN API

### DIFF
--- a/src/modules/account/repositories/account/__spec__/account.repository.spec.ts
+++ b/src/modules/account/repositories/account/__spec__/account.repository.spec.ts
@@ -89,6 +89,29 @@ describe(AccountRepository, () => {
     });
   });
 
+  describe(AccountRepository.prototype.findManyByAvatarFileNames, () => {
+    let avatarFileNames: Set<string>;
+    let accounts: Account[];
+
+    beforeEach(async () => {
+      avatarFileNames = new Set<string>();
+      accounts = await Promise.all(
+        AccountFactory.buildList(3).map((account) => {
+          avatarFileNames.add(account.avatarFileName as string);
+          return repository.insert(account);
+        }),
+      );
+    });
+
+    describe('이미지 파일명 리스트를 주면', () => {
+      it('이미지 파일명에 맞는 퀴즈 목록을 반환해야 한다.', async () => {
+        await expect(
+          repository.findManyByAvatarFileNames(avatarFileNames),
+        ).resolves.toEqual(expect.arrayContaining(accounts));
+      });
+    });
+  });
+
   describe(AccountRepository.prototype.findOneByUsername, () => {
     let username: string;
 

--- a/src/modules/account/repositories/account/account.repository.port.ts
+++ b/src/modules/account/repositories/account/account.repository.port.ts
@@ -20,6 +20,7 @@ export interface AccountOrder {}
 export interface AccountRepositoryPort
   extends RepositoryPort<Account, AccountFilter, AccountOrder> {
   findAllBy(options: { filter: AccountFilter }): Promise<Account[]>;
+  findManyByAvatarFileNames(avatarFileName: Set<string>): Promise<Account[]>;
   findOneByUsername(username: string): Promise<Account | undefined>;
   findOneByNickname(nickname: string): Promise<Account | undefined>;
   findOneBySocialId(

--- a/src/modules/account/repositories/account/account.repository.ts
+++ b/src/modules/account/repositories/account/account.repository.ts
@@ -55,6 +55,20 @@ export class AccountRepository
     return accounts.map((account) => this.mapper.toEntity(account));
   }
 
+  async findManyByAvatarFileNames(
+    avatarFileName: Set<string>,
+  ): Promise<Account[]> {
+    const accounts = await this.txHost.tx.account.findMany({
+      where: {
+        avatarFileName: {
+          in: Array.from(avatarFileName),
+        },
+      },
+    });
+
+    return accounts.map((account) => this.mapper.toEntity(account));
+  }
+
   async findOneByUsername(username: string): Promise<Account | undefined> {
     const account = await this.txHost.tx.account.findFirst({
       where: {

--- a/src/modules/avatar/avatar.module.ts
+++ b/src/modules/avatar/avatar.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { CreateAvatarModule } from '@module/avatar/use-cases/create-avatar/create-avatar.module';
+import { DeleteAvatarModule } from '@module/avatar/use-cases/delete-avatar/delete-avatar.module';
 import { GetAvatarModule } from '@module/avatar/use-cases/get-avatar/get-avatar.module';
 import { ListAvatarsModule } from '@module/avatar/use-cases/list-avatars/list-avatars.module';
 import { UpdateAvatarModule } from '@module/avatar/use-cases/update-avatar/update-avatar.module';
@@ -8,6 +9,7 @@ import { UpdateAvatarModule } from '@module/avatar/use-cases/update-avatar/updat
 @Module({
   imports: [
     CreateAvatarModule,
+    DeleteAvatarModule,
     GetAvatarModule,
     ListAvatarsModule,
     UpdateAvatarModule,

--- a/src/modules/avatar/entities/avatar.entity.ts
+++ b/src/modules/avatar/entities/avatar.entity.ts
@@ -2,6 +2,7 @@ import { TSID } from 'tsid-ts';
 
 import { AvatarAssignedEvent } from '@module/avatar/events/avatar-assigned.event';
 import { AvatarCreatedEvent } from '@module/avatar/events/avatar-created.event';
+import { AvatarDeletedEvent } from '@module/avatar/events/avatar-deleted-event';
 import { AvatarUpdatedEvent } from '@module/avatar/events/avatar-updated-event';
 
 import {
@@ -151,6 +152,14 @@ export class Avatar extends AggregateRoot<AvatarProps> {
       new AvatarUpdatedEvent(this.id, {
         name: props.name,
         description: props.description,
+      }),
+    );
+  }
+
+  delete() {
+    this.apply(
+      new AvatarDeletedEvent(this.id, {
+        avatarId: this.id,
       }),
     );
   }

--- a/src/modules/avatar/errors/avatar-in-used.error.ts
+++ b/src/modules/avatar/errors/avatar-in-used.error.ts
@@ -1,0 +1,9 @@
+import { BaseError } from '@common/base/base.error';
+
+export class AvatarInUsedError extends BaseError {
+  static CODE = 'AVATAR.IN_USED';
+
+  constructor(message?: string) {
+    super(message ?? 'Avatar is in used', AvatarInUsedError.CODE);
+  }
+}

--- a/src/modules/avatar/events/avatar-deleted-event.ts
+++ b/src/modules/avatar/events/avatar-deleted-event.ts
@@ -1,0 +1,9 @@
+import { DomainEvent } from '@common/base/base.domain-event';
+
+export interface AvatarDeletedEventPayload {
+  avatarId: string;
+}
+
+export class AvatarDeletedEvent extends DomainEvent<AvatarDeletedEventPayload> {
+  readonly aggregate = 'Avatar';
+}

--- a/src/modules/avatar/use-cases/delete-avatar/__spec__/delete-avatar-command.factory.ts
+++ b/src/modules/avatar/use-cases/delete-avatar/__spec__/delete-avatar-command.factory.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'rosie';
+
+import { DeleteAvatarCommand } from '@module/avatar/use-cases/delete-avatar/delete-avatar.command';
+
+import { generateEntityId } from '@common/base/base.entity';
+
+export const DeleteAvatarCommandFactory = Factory.define<DeleteAvatarCommand>(
+  DeleteAvatarCommand.name,
+  DeleteAvatarCommand,
+).attrs({
+  avatarId: () => generateEntityId(),
+});

--- a/src/modules/avatar/use-cases/delete-avatar/__spec__/delete-avatar.handler.spec.ts
+++ b/src/modules/avatar/use-cases/delete-avatar/__spec__/delete-avatar.handler.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AccountFactory } from '@module/account/entities/__spec__/account.factory';
+import { AccountRepositoryModule } from '@module/account/repositories/account/account.repository.module';
+import {
+  ACCOUNT_REPOSITORY,
+  AccountRepositoryPort,
+} from '@module/account/repositories/account/account.repository.port';
+import { AvatarFactory } from '@module/avatar/entities/__spec__/avatar.factory';
+import { Avatar } from '@module/avatar/entities/avatar.entity';
+import { AvatarInUsedError } from '@module/avatar/errors/avatar-in-used.error';
+import { AvatarNotFoundError } from '@module/avatar/errors/avatar-not-found.error';
+import { AvatarRepositoryModule } from '@module/avatar/repositories/avatar/avatar.repository.module';
+import {
+  AVATAR_REPOSITORY,
+  AvatarRepositoryPort,
+} from '@module/avatar/repositories/avatar/avatar.repository.port';
+import { DeleteAvatarCommandFactory } from '@module/avatar/use-cases/delete-avatar/__spec__/delete-avatar-command.factory';
+import { DeleteAvatarCommand } from '@module/avatar/use-cases/delete-avatar/delete-avatar.command';
+import { DeleteAvatarHandler } from '@module/avatar/use-cases/delete-avatar/delete-avatar.handler';
+
+import { AppConfigModule } from '@common/app-config/app-config.module';
+import { ClsModuleFactory } from '@common/factories/cls-module.factory';
+
+import { AwsS3Module } from '@shared/services/aws-s3/aws-s3.module';
+import { AWS_S3_PORT, AwsS3Port } from '@shared/services/aws-s3/aws-s3.port';
+
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
+describe(DeleteAvatarHandler.name, () => {
+  let handler: DeleteAvatarHandler;
+
+  let avatarRepository: AvatarRepositoryPort;
+  let accountRepository: AccountRepositoryPort;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let awsS3Adapter: AwsS3Port;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let eventStore: IEventStore;
+
+  let command: DeleteAvatarCommand;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ClsModuleFactory(),
+        AppConfigModule,
+        AvatarRepositoryModule,
+        AccountRepositoryModule,
+        AwsS3Module,
+        EventStoreModule,
+      ],
+      providers: [DeleteAvatarHandler],
+    }).compile();
+
+    handler = module.get<DeleteAvatarHandler>(DeleteAvatarHandler);
+
+    avatarRepository = module.get<AvatarRepositoryPort>(AVATAR_REPOSITORY);
+    accountRepository = module.get<AccountRepositoryPort>(ACCOUNT_REPOSITORY);
+    awsS3Adapter = module.get<AwsS3Port>(AWS_S3_PORT);
+    eventStore = module.get<IEventStore>(EVENT_STORE);
+  });
+
+  beforeEach(() => {
+    command = DeleteAvatarCommandFactory.build();
+  });
+
+  beforeEach(() => {
+    jest.spyOn(awsS3Adapter, 'deleteFile').mockResolvedValue(undefined);
+  });
+
+  describe('아바타를 삭제하면 ', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let avatar: Avatar;
+
+    beforeEach(async () => {
+      avatar = await avatarRepository.insert(
+        AvatarFactory.build({ id: command.avatarId }),
+      );
+    });
+
+    it('아바타가 삭제돼야한다.', async () => {
+      await expect(handler.execute(command)).resolves.toBeUndefined();
+
+      await expect(
+        avatarRepository.findOneById(command.avatarId),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('아바타가 존재하지 않는 경우', () => {
+    it('아바타가 존재하지 않는다는 에러가 발생해야한다.', async () => {
+      await expect(handler.execute(command)).rejects.toThrow(
+        AvatarNotFoundError,
+      );
+    });
+  });
+
+  describe('아바타를 사용중인 계정이 존재하는 경우', () => {
+    beforeEach(async () => {
+      const avatar = await avatarRepository.insert(
+        AvatarFactory.build({ id: command.avatarId }),
+      );
+      await accountRepository.insert(
+        AccountFactory.build({ avatarFileName: avatar.fileName }),
+      );
+    });
+
+    it('사용중인 아바타느 삭제할 수 없다는 에러가 발생해야한다.', async () => {
+      await expect(handler.execute(command)).rejects.toThrowError(
+        AvatarInUsedError,
+      );
+    });
+  });
+});

--- a/src/modules/avatar/use-cases/delete-avatar/delete-avatar.command.ts
+++ b/src/modules/avatar/use-cases/delete-avatar/delete-avatar.command.ts
@@ -1,0 +1,13 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export interface IDeleteAvatarCommandProps {
+  avatarId: string;
+}
+
+export class DeleteAvatarCommand implements ICommand {
+  readonly avatarId: string;
+
+  constructor(props: IDeleteAvatarCommandProps) {
+    this.avatarId = props.avatarId;
+  }
+}

--- a/src/modules/avatar/use-cases/delete-avatar/delete-avatar.controller.ts
+++ b/src/modules/avatar/use-cases/delete-avatar/delete-avatar.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Param,
+} from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import { ApiNoContentResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { AvatarInUsedError } from '@module/avatar/errors/avatar-in-used.error';
+import { AvatarNotFoundError } from '@module/avatar/errors/avatar-not-found.error';
+import { DeleteAvatarCommand } from '@module/avatar/use-cases/delete-avatar/delete-avatar.command';
+
+import { BaseHttpException } from '@common/base/base-http-exception';
+import {
+  PermissionDeniedError,
+  RequestValidationError,
+  UnauthorizedError,
+} from '@common/base/base.error';
+import { ApiErrorResponse } from '@common/decorator/api-fail-response.decorator';
+import { ParsePositiveIntStringPipe } from '@common/pipes/positive-int-string.pipe';
+
+@ApiTags('avatar')
+@Controller()
+export class DeleteAvatarController {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  @ApiOperation({ summary: '아바타 삭제' })
+  @ApiErrorResponse({
+    [HttpStatus.BAD_REQUEST]: [RequestValidationError],
+    [HttpStatus.UNAUTHORIZED]: [UnauthorizedError],
+    [HttpStatus.FORBIDDEN]: [PermissionDeniedError],
+    [HttpStatus.NOT_FOUND]: [AvatarNotFoundError],
+    [HttpStatus.CONFLICT]: [AvatarInUsedError],
+  })
+  @ApiNoContentResponse({})
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Delete('admin/avatars/:avatarId')
+  async deleteAvatarAdmin(
+    @Param('avatarId', ParsePositiveIntStringPipe) avatarId: string,
+  ): Promise<void> {
+    try {
+      const command = new DeleteAvatarCommand({
+        avatarId,
+      });
+
+      await this.commandBus.execute<DeleteAvatarCommand, void>(command);
+    } catch (error) {
+      if (error instanceof AvatarNotFoundError) {
+        throw new BaseHttpException(HttpStatus.NOT_FOUND, error);
+      }
+
+      if (error instanceof AvatarInUsedError) {
+        throw new BaseHttpException(HttpStatus.CONFLICT, error);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/avatar/use-cases/delete-avatar/delete-avatar.handler.ts
+++ b/src/modules/avatar/use-cases/delete-avatar/delete-avatar.handler.ts
@@ -1,0 +1,68 @@
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { Transactional } from '@nestjs-cls/transactional';
+
+import {
+  ACCOUNT_REPOSITORY,
+  AccountRepositoryPort,
+} from '@module/account/repositories/account/account.repository.port';
+import { AvatarInUsedError } from '@module/avatar/errors/avatar-in-used.error';
+import { AvatarNotFoundError } from '@module/avatar/errors/avatar-not-found.error';
+import {
+  AVATAR_REPOSITORY,
+  AvatarRepositoryPort,
+} from '@module/avatar/repositories/avatar/avatar.repository.port';
+import { DeleteAvatarCommand } from '@module/avatar/use-cases/delete-avatar/delete-avatar.command';
+
+import { AWS_S3_PORT, AwsS3Port } from '@shared/services/aws-s3/aws-s3.port';
+
+import {
+  EVENT_STORE,
+  IEventStore,
+} from '@core/event-sourcing/event-store.interface';
+
+@CommandHandler(DeleteAvatarCommand)
+export class DeleteAvatarHandler
+  implements ICommandHandler<DeleteAvatarCommand, void>
+{
+  constructor(
+    @Inject(AVATAR_REPOSITORY)
+    private readonly avatarRepository: AvatarRepositoryPort,
+    @Inject(ACCOUNT_REPOSITORY)
+    private readonly accountRepository: AccountRepositoryPort,
+    @Inject(AWS_S3_PORT)
+    private readonly awsS3Adapter: AwsS3Port,
+    @Inject(EVENT_STORE)
+    private readonly eventStore: IEventStore,
+  ) {}
+
+  @Transactional()
+  async execute(command: DeleteAvatarCommand): Promise<void> {
+    const avatar = await this.avatarRepository.findOneById(command.avatarId);
+
+    if (avatar === undefined) {
+      throw new AvatarNotFoundError();
+    }
+
+    const avatarUsingAccounts =
+      await this.accountRepository.findManyByAvatarFileNames(
+        new Set([avatar.fileName]),
+      );
+
+    if (avatarUsingAccounts.length > 0) {
+      throw new AvatarInUsedError();
+    }
+
+    avatar.delete();
+
+    await this.avatarRepository.delete(avatar);
+
+    await this.eventStore.storeAggregateEvents(avatar);
+
+    await this.awsS3Adapter.deleteFile({
+      type: 'avatar',
+      fileName: avatar.fileName,
+    });
+  }
+}

--- a/src/modules/avatar/use-cases/delete-avatar/delete-avatar.module.ts
+++ b/src/modules/avatar/use-cases/delete-avatar/delete-avatar.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+
+import { AccountRepositoryModule } from '@module/account/repositories/account/account.repository.module';
+import { AvatarRepositoryModule } from '@module/avatar/repositories/avatar/avatar.repository.module';
+import { DeleteAvatarController } from '@module/avatar/use-cases/delete-avatar/delete-avatar.controller';
+import { DeleteAvatarHandler } from '@module/avatar/use-cases/delete-avatar/delete-avatar.handler';
+
+import { AwsS3Module } from '@shared/services/aws-s3/aws-s3.module';
+
+import { EventStoreModule } from '@core/event-sourcing/event-store.module';
+
+@Module({
+  imports: [
+    EventStoreModule,
+    AwsS3Module,
+    AvatarRepositoryModule,
+    AccountRepositoryModule,
+  ],
+  controllers: [DeleteAvatarController],
+  providers: [DeleteAvatarHandler],
+})
+export class DeleteAvatarModule {}


### PR DESCRIPTION
### Short description

아바타 삭제 ADMIN API

### Proposed changes

- 아바타 삭제 ADMIN API

### How to test (Optional)

```bash
curl -X 'DELETE' \
  'http://localhost:4000/admin/avatars/775663493916417331' \
  -H 'accept: */*' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3Njk4NTIwMTAxOTAxNDU1NjIiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NjI3NDkxNDMsImV4cCI6MTc5NDMwNjc0MywiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.OpWJ4hE3MjXavwmU7ZS62mFDwb0vh3fSRMUCbVR8F28'
```

### Reference (Optional)

Closes #169 
