### PR TITLE
게임방 구성원에 아바타 추가

### DIFF
--- a/prisma.d.ts
+++ b/prisma.d.ts
@@ -7,6 +7,7 @@ namespace PrismaJson {
     accountId: bigint;
     role: GameRoomMemberRole;
     nickname: string;
+    avatarFileName: string;
     createdAt: string;
     updatedAt: string;
   };

--- a/prisma/migrations/20251113102547_member_avatar/migration.sql
+++ b/prisma/migrations/20251113102547_member_avatar/migration.sql
@@ -1,0 +1,11 @@
+UPDATE game_room
+SET members = (
+  SELECT array_agg(
+    CASE
+      WHEN member ? 'avatarFileName' THEN member
+      ELSE member || jsonb_build_object('avatarFileName', 'pendingImage')
+    END
+  )
+  FROM unnest(members) AS member
+)
+WHERE members IS NOT NULL;

--- a/src/modules/game-room/assemblers/game-room-member-dto.assembler.ts
+++ b/src/modules/game-room/assemblers/game-room-member-dto.assembler.ts
@@ -2,6 +2,8 @@ import { GameRoomMemberSocketEventDto } from '@module/game-room/dto/game-room-me
 import { GameRoomMemberDto } from '@module/game-room/dto/game-room-member.dto';
 import { GameRoomMember } from '@module/game-room/entities/game-room-member.entity';
 
+import { AssetUrlManager } from '@shared/asset/asset-url.manager';
+
 export class GameRoomMemberDtoAssembler {
   static convertToDto(gameRoomMember: GameRoomMember): GameRoomMemberDto {
     const dto = new GameRoomMemberDto({
@@ -13,6 +15,10 @@ export class GameRoomMemberDtoAssembler {
     dto.accountId = gameRoomMember.accountId;
     dto.role = gameRoomMember.role;
     dto.nickname = gameRoomMember.nickname;
+    dto.avatarUrl = AssetUrlManager.fileNameToUrl(
+      gameRoomMember.avatarFileName,
+      'avatar',
+    );
 
     return dto;
   }
@@ -26,6 +32,10 @@ export class GameRoomMemberDtoAssembler {
     dto.accountId = gameRoomMember.accountId;
     dto.role = gameRoomMember.role;
     dto.nickname = gameRoomMember.nickname;
+    dto.avatarUrl = AssetUrlManager.fileNameToUrl(
+      gameRoomMember.avatarFileName,
+      'avatar',
+    );
 
     return dto;
   }

--- a/src/modules/game-room/dto/game-room-member-socket-event.dto.ts
+++ b/src/modules/game-room/dto/game-room-member-socket-event.dto.ts
@@ -18,4 +18,7 @@ export class GameRoomMemberSocketEventDto {
 
   @ApiProperty()
   nickname: string;
+
+  @ApiProperty()
+  avatarUrl: string;
 }

--- a/src/modules/game-room/dto/game-room-member.dto.ts
+++ b/src/modules/game-room/dto/game-room-member.dto.ts
@@ -20,4 +20,7 @@ export class GameRoomMemberDto extends BaseResponseDto {
     description: '게임방 구성원의 닉네임(계정 닉네임과 동일함)',
   })
   nickname: string;
+
+  @ApiProperty()
+  avatarUrl: string;
 }

--- a/src/modules/game-room/entities/__spec__/game-room-member.factory.ts
+++ b/src/modules/game-room/entities/__spec__/game-room-member.factory.ts
@@ -17,6 +17,7 @@ export const GameRoomMemberFactory = Factory.define<
     accountId: () => generateEntityId(),
     role: () => faker.helpers.enumValue(GameRoomMemberRole),
     nickname: () => generateEntityId(),
+    avatarFileName: () => faker.string.nanoid(),
     createdAt: () => new Date(),
     updatedAt: () => new Date(),
   })

--- a/src/modules/game-room/entities/__spec__/game-room.entity.spec.ts
+++ b/src/modules/game-room/entities/__spec__/game-room.entity.spec.ts
@@ -34,6 +34,7 @@ describe(GameRoom, () => {
         quizzesCount: 5,
         hostAccountId: generateEntityId(),
         hostNickname: 'nickname',
+        hostAvatarFileName: 'avatarFileName',
       };
     });
 

--- a/src/modules/game-room/entities/game-room-member.entity.ts
+++ b/src/modules/game-room/entities/game-room-member.entity.ts
@@ -13,12 +13,14 @@ export interface GameRoomMemberProps {
   accountId: string;
   role: GameRoomMemberRole;
   nickname: string;
+  avatarFileName: string;
 }
 
 interface CreateGameRoomMemberProps {
   accountId: string;
   role: GameRoomMemberRole;
   nickname: string;
+  avatarFileName: string;
 }
 
 export class GameRoomMember extends BaseEntity<GameRoomMemberProps> {
@@ -36,6 +38,7 @@ export class GameRoomMember extends BaseEntity<GameRoomMemberProps> {
         accountId: props.accountId,
         role: props.role,
         nickname: props.nickname,
+        avatarFileName: props.avatarFileName,
       },
       createdAt: date,
       updatedAt: date,
@@ -52,6 +55,10 @@ export class GameRoomMember extends BaseEntity<GameRoomMemberProps> {
 
   get nickname(): string {
     return this.props.nickname;
+  }
+
+  get avatarFileName(): string {
+    return this.props.avatarFileName;
   }
 
   changeRole(role: GameRoomMemberRole) {

--- a/src/modules/game-room/entities/game-room.entity.ts
+++ b/src/modules/game-room/entities/game-room.entity.ts
@@ -52,6 +52,7 @@ interface CreateGameRoomProps {
   quizzesCount: number;
   hostAccountId: string;
   hostNickname: string;
+  hostAvatarFileName: string;
 }
 
 export class GameRoom extends AggregateRoot<GameRoomProps> {
@@ -101,6 +102,7 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
         accountId: props.hostAccountId,
         nickname: props.hostNickname,
         role: GameRoomMemberRole.host,
+        avatarFileName: props.hostAvatarFileName,
       }),
     );
 
@@ -198,6 +200,7 @@ export class GameRoom extends AggregateRoot<GameRoomProps> {
         accountId: member.accountId,
         role: member.role,
         nickname: member.nickname,
+        avatarFileName: member.avatarFileName,
       }),
     );
 

--- a/src/modules/game-room/events/game-room-member-joined/__spec__/game-room-member-joined.handler.spec.ts
+++ b/src/modules/game-room/events/game-room-member-joined/__spec__/game-room-member-joined.handler.spec.ts
@@ -66,6 +66,7 @@ describe(GameRoomMemberJoinedHandler, () => {
       accountId: generateEntityId(),
       role: GameRoomMemberRole.player,
       nickname: generateEntityId(),
+      avatarFileName: 'avatarFileName',
     });
   });
 

--- a/src/modules/game-room/events/game-room-member-joined/game-room-member-joined.event.ts
+++ b/src/modules/game-room/events/game-room-member-joined/game-room-member-joined.event.ts
@@ -7,6 +7,7 @@ interface GameRoomMemberJoinedEventPayload {
   accountId: string;
   role: GameRoomMemberRole;
   nickname: string;
+  avatarFileName: string;
 }
 
 export class GameRoomMemberJoinedEvent extends DomainEvent<GameRoomMemberJoinedEventPayload> {

--- a/src/modules/game-room/mappers/game-room-member.mapper.ts
+++ b/src/modules/game-room/mappers/game-room-member.mapper.ts
@@ -16,6 +16,7 @@ export class GameRoomMemberMapper extends BaseMapper {
         accountId: this.toEntityId(raw.accountId),
         role: GameRoomMemberRole[raw.role],
         nickname: raw.nickname,
+        avatarFileName: raw.avatarFileName,
       },
     });
   }
@@ -28,6 +29,7 @@ export class GameRoomMemberMapper extends BaseMapper {
       accountId: this.toPrimaryKey(entity.props.accountId),
       role: entity.props.role as PrismaJson.GameRoomMemberRole,
       nickname: entity.props.nickname,
+      avatarFileName: entity.avatarFileName,
     };
   }
 }

--- a/src/modules/game-room/use-cases/create-game-room/create-game-room.handler.ts
+++ b/src/modules/game-room/use-cases/create-game-room/create-game-room.handler.ts
@@ -52,6 +52,7 @@ export class CreateGameRoomHandler
       hostAccountId: command.currentAccountId,
       hostNickname: existingAccount.nickname,
       quizTimeLimitInSeconds: GameRoom.DEFAULT_QUIZ_TIME_LIMIT_IN_SECONDS,
+      hostAvatarFileName: existingAccount.avatarFileName,
     });
 
     await this.gameRoomRepository.insert(gameRoom);

--- a/src/modules/game-room/use-cases/join-game-room/join-game-room.handler.ts
+++ b/src/modules/game-room/use-cases/join-game-room/join-game-room.handler.ts
@@ -51,6 +51,7 @@ export class JoinGameRoomHandler
         accountId: command.currentAccountId,
         role: command.role,
         nickname: existingAccount.nickname,
+        avatarFileName: existingAccount.avatarFileName,
       }),
     );
 


### PR DESCRIPTION
### Short description

게임방 구성원에 아바타 추가

### Proposed changes

- 데이터베이스 스키마에 avatarFileName추가
   - 기본값으로 pendingImage로 하고 추후 마이그레이션
- 구성원 도메인에 avatarFileName추가
- REST API 응답으로 avatarUrl추가
- 소켓 응답으로 avatarUrl추가

### How to test (Optional)

게임 방 생성 응답으로 구성원 객체에 avatar Url이 있는지 확인 

```bash
curl -X 'POST' \
  'http://localhost:4000/game-rooms' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3Njk4NTIwMTAxOTAxNDU1NjIiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NjI3NDkxNDMsImV4cCI6MTc5NDMwNjc0MywiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.OpWJ4hE3MjXavwmU7ZS62mFDwb0vh3fSRMUCbVR8F28' \
  -H 'Content-Type: application/json' \
  -d '{
  "title": "My Awesome Game Room",
  "quizzesCount": 100
}'
```

### Reference (Optional)

Closes #187 
