### PR TITLE
어드민 퀴즈 리스트 조회 API에 페이지네이션 추가

### DIFF
--- a/src/modules/quiz/assemblers/quiz-collection-dto.assembler.ts
+++ b/src/modules/quiz/assemblers/quiz-collection-dto.assembler.ts
@@ -2,11 +2,17 @@ import { QuizDtoAssembler } from '@module/quiz/assemblers/quiz-dto.assembler';
 import { QuizCollectionAdminDto } from '@module/quiz/dto/quiz-collection.admin-dto';
 import { Quiz } from '@module/quiz/entities/quiz.entity';
 
+import { OffsetPage } from '@common/base/base.entity';
+
 export class QuizCollectionDtoAssembler {
-  static convertToAdminDto(quizzes: Quiz[]): QuizCollectionAdminDto {
+  static convertToAdminDto(page: OffsetPage<Quiz>): QuizCollectionAdminDto {
     const dto = new QuizCollectionAdminDto();
 
-    dto.data = quizzes.map((quiz) => QuizDtoAssembler.convertToAdminDto(quiz));
+    dto.data = page.data.map(QuizDtoAssembler.convertToAdminDto);
+    dto.currentPage = page.currentPage;
+    dto.perPage = page.perPage;
+    dto.totalCount = page.totalCount;
+    dto.totalPages = page.totalPages;
 
     return dto;
   }

--- a/src/modules/quiz/dto/quiz-collection.admin-dto.ts
+++ b/src/modules/quiz/dto/quiz-collection.admin-dto.ts
@@ -2,7 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { QuizAdminDto } from '@module/quiz/dto/quiz.admin-dto';
 
-export class QuizCollectionAdminDto {
+import { BaseOffsetPaginationResponseDto } from '@common/base/base.dto';
+
+export class QuizCollectionAdminDto extends BaseOffsetPaginationResponseDto<QuizAdminDto> {
   @ApiProperty({
     type: [QuizAdminDto],
   })

--- a/src/modules/quiz/repositories/quiz/__spec__/quiz.repository.spec.ts
+++ b/src/modules/quiz/repositories/quiz/__spec__/quiz.repository.spec.ts
@@ -69,20 +69,27 @@ describe(QuizRepository, () => {
     });
   });
 
-  describe(QuizRepository.prototype.findAll, () => {
+  describe(QuizRepository.prototype.findAllOffsetPaginated, () => {
     let quizzes: Quiz[];
 
     beforeEach(async () => {
       quizzes = await Promise.all(
-        QuizFactory.buildList(3).map((quiz) => repository.insert(quiz)),
+        QuizFactory.buildList(5).map((quiz) => repository.insert(quiz)),
       );
     });
 
-    describe('모든 퀴즈 목록을 조회하면', () => {
-      it('모든 퀴즈 목록을 반환해야 한다.', async () => {
-        await expect(repository.findAll({})).resolves.toEqual(
-          expect.arrayContaining(quizzes),
-        );
+    describe('페이지를 조회하면', () => {
+      it('페이지가 반환되어야한다.', async () => {
+        await expect(
+          repository.findAllOffsetPaginated({
+            pageInfo: { offset: 0, limit: 2 },
+          }),
+        ).resolves.toEqual({
+          data: expect.toSatisfyAll((quiz: unknown) => quiz instanceof Quiz),
+          limit: expect.any(Number),
+          offset: expect.any(Number),
+          totalCount: expect.any(Number),
+        });
       });
     });
 
@@ -95,10 +102,16 @@ describe(QuizRepository, () => {
 
       it('해당 이미지 파일명을 가진 퀴즈 목록을 반환해야 한다.', async () => {
         await expect(
-          repository.findAll({
+          repository.findAllOffsetPaginated({
+            pageInfo: { offset: 0, limit: 2 },
             filter: { imageFileName: targetQuiz.imageFileName as string },
           }),
-        ).resolves.toEqual(expect.arrayContaining([targetQuiz]));
+        ).resolves.toEqual({
+          data: expect.arrayContaining([targetQuiz]),
+          limit: expect.any(Number),
+          offset: expect.any(Number),
+          totalCount: expect.any(Number),
+        });
       });
     });
   });

--- a/src/modules/quiz/repositories/quiz/quiz.repository.port.ts
+++ b/src/modules/quiz/repositories/quiz/quiz.repository.port.ts
@@ -2,7 +2,11 @@ import { Quiz as QuizModel } from '@prisma/client';
 
 import { Quiz } from '@module/quiz/entities/quiz.entity';
 
-import { ISort, RepositoryPort } from '@common/base/base.repository';
+import {
+  IOffsetPaginated,
+  ISort,
+  RepositoryPort,
+} from '@common/base/base.repository';
 
 export const QUIZ_REPOSITORY = Symbol('QUIZ_REPOSITORY');
 
@@ -12,11 +16,22 @@ export interface QuizFilter {
   imageFileName?: string;
 }
 
+export interface FindAllQuizzesOffsetPaginatedParams {
+  filter?: QuizFilter;
+  pageInfo: {
+    offset: number;
+    limit: number;
+  };
+  order?: ISort<'createdAt'>[];
+}
+
 export interface QuizOrder extends ISort<'createdAt'> {}
 
 export interface QuizRepositoryPort
   extends RepositoryPort<Quiz, QuizFilter, QuizOrder> {
   insertMany(quizzes: Quiz[]): Promise<void>;
-  findAll(params: { filter?: QuizFilter }): Promise<Quiz[]>;
+  findAllOffsetPaginated(
+    params: FindAllQuizzesOffsetPaginatedParams,
+  ): Promise<IOffsetPaginated<Quiz>>;
   findManyByFileNames(fileNames: Set<string>): Promise<Quiz[]>;
 }

--- a/src/modules/quiz/repositories/quiz/quiz.repository.ts
+++ b/src/modules/quiz/repositories/quiz/quiz.repository.ts
@@ -10,6 +10,7 @@ import { Prisma } from '@prisma/client';
 import { Quiz } from '@module/quiz/entities/quiz.entity';
 import { QuizMapper } from '@module/quiz/mappers/quiz.mapper';
 import {
+  FindAllQuizzesOffsetPaginatedParams,
   QuizFilter,
   QuizOrder,
   QuizRaw,
@@ -20,6 +21,7 @@ import {
   BaseRepository,
   ICursorPaginated,
   ICursorPaginatedParams,
+  IOffsetPaginated,
 } from '@common/base/base.repository';
 
 @Injectable()
@@ -42,18 +44,33 @@ export class QuizRepository
     });
   }
 
-  async findAll(params: { filter: QuizFilter }): Promise<Quiz[]> {
+  async findAllOffsetPaginated(
+    params: FindAllQuizzesOffsetPaginatedParams,
+  ): Promise<IOffsetPaginated<Quiz>> {
+    const { pageInfo, order, filter } = params;
+
     const where: Prisma.QuizWhereInput = {};
 
-    if (params.filter?.imageFileName !== undefined) {
-      where.imageFileName = params.filter.imageFileName;
+    if (filter?.imageFileName !== undefined) {
+      where.imageFileName = filter.imageFileName;
     }
 
-    const quizzes = await this.txHost.tx.quiz.findMany({
-      where,
-    });
+    const [quizzes, totalCount] = await Promise.all([
+      this.txHost.tx.quiz.findMany({
+        skip: pageInfo.offset,
+        take: pageInfo.limit,
+        orderBy: this.toOrderBy(order ?? [{ field: 'id', direction: 'asc' }]),
+        where,
+      }),
+      this.txHost.tx.quiz.count({ where }),
+    ]);
 
-    return quizzes.map((quiz) => this.mapper.toEntity(quiz));
+    return {
+      offset: pageInfo.offset,
+      limit: pageInfo.limit,
+      totalCount: totalCount,
+      data: quizzes.map((quiz) => this.mapper.toEntity(quiz)),
+    };
   }
 
   async findManyByFileNames(fileNames: Set<string>): Promise<Quiz[]> {

--- a/src/modules/quiz/use-cases/list-quizzes/__spec__/list-quizzes.handler.spec.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/__spec__/list-quizzes.handler.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { QuizFactory } from '@module/quiz/entities/__spec__/quiz.factory';
-import { Quiz } from '@module/quiz/entities/quiz.entity';
 import { QuizRepositoryModule } from '@module/quiz/repositories/quiz/quiz.repository.module';
 import {
   QUIZ_REPOSITORY,
@@ -41,11 +40,15 @@ describe(ListQuizzesHandler.name, () => {
     );
   });
 
-  describe('퀴즈 목록을 조회하면', () => {
-    it('Quiz 인스턴스로 구성된 배열을 반환해야 한다.', async () => {
-      await expect(handler.execute(query)).resolves.toSatisfyAll<Quiz>(
-        (quiz) => quiz instanceof Quiz,
-      );
+  describe('퀴즈 목록 페이지를 조회하면', () => {
+    it('퀴즈 목록 페이지가 반환돼야한다.', async () => {
+      const result = await handler.execute(query);
+
+      expect(result).toBeDefined();
+      expect(result.data.length).toBeGreaterThanOrEqual(0);
+      expect(result.currentPage).toBe(query.page ?? 1);
+      expect(result.perPage).toBe(query.perPage ?? 20);
+      expect(result.totalCount).toBeGreaterThanOrEqual(0);
     });
   });
 });

--- a/src/modules/quiz/use-cases/list-quizzes/list-quizzes.controller.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/list-quizzes.controller.ts
@@ -8,6 +8,7 @@ import { Quiz } from '@module/quiz/entities/quiz.entity';
 import { ListQuizzesDto } from '@module/quiz/use-cases/list-quizzes/list-quizzes.dto';
 import { ListQuizzesQuery } from '@module/quiz/use-cases/list-quizzes/list-quizzes.query';
 
+import { OffsetPage } from '@common/base/base.entity';
 import {
   PermissionDeniedError,
   RequestValidationError,
@@ -35,10 +36,11 @@ export class ListQuizzesController {
       imageFileName: dto.imageFileName,
     });
 
-    const quizzes = await this.queryBus.execute<ListQuizzesQuery, Quiz[]>(
-      query,
-    );
+    const offsetPage = await this.queryBus.execute<
+      ListQuizzesQuery,
+      OffsetPage<Quiz>
+    >(query);
 
-    return QuizCollectionDtoAssembler.convertToAdminDto(quizzes);
+    return QuizCollectionDtoAssembler.convertToAdminDto(offsetPage);
   }
 }

--- a/src/modules/quiz/use-cases/list-quizzes/list-quizzes.dto.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/list-quizzes.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class ListQuizzesDto {
   @ApiProperty({
@@ -10,4 +11,27 @@ export class ListQuizzesDto {
   @IsString()
   @IsOptional()
   imageFileName?: string;
+
+  @ApiProperty({
+    required: false,
+    minimum: 1,
+  })
+  @Min(1)
+  @IsInt()
+  @IsOptional()
+  @Type(() => Number)
+  page?: number;
+
+  @ApiProperty({
+    required: false,
+    minimum: 5,
+    maximum: 1000,
+    default: 20,
+  })
+  @Max(1000)
+  @Min(5)
+  @IsInt()
+  @IsOptional()
+  @Type(() => Number)
+  perPage?: number;
 }

--- a/src/modules/quiz/use-cases/list-quizzes/list-quizzes.handler.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/list-quizzes.handler.ts
@@ -8,18 +8,26 @@ import {
 } from '@module/quiz/repositories/quiz/quiz.repository.port';
 import { ListQuizzesQuery } from '@module/quiz/use-cases/list-quizzes/list-quizzes.query';
 
+import { OffsetPage } from '@common/base/base.entity';
+
 @QueryHandler(ListQuizzesQuery)
 export class ListQuizzesHandler
-  implements IQueryHandler<ListQuizzesQuery, Quiz[]>
+  implements IQueryHandler<ListQuizzesQuery, OffsetPage<Quiz>>
 {
   constructor(
     @Inject(QUIZ_REPOSITORY)
     private readonly quizRepository: QuizRepositoryPort,
   ) {}
 
-  async execute(query: ListQuizzesQuery): Promise<Quiz[]> {
-    return await this.quizRepository.findAll({
+  async execute(query: ListQuizzesQuery): Promise<OffsetPage<Quiz>> {
+    const page = query.page ?? 1;
+    const perPage = query.perPage ?? 20;
+
+    const result = await this.quizRepository.findAllOffsetPaginated({
+      pageInfo: { offset: (page - 1) * perPage, limit: perPage },
       filter: { imageFileName: query.imageFileName },
     });
+
+    return new OffsetPage(result.data, page, perPage, result.totalCount);
   }
 }

--- a/src/modules/quiz/use-cases/list-quizzes/list-quizzes.query.ts
+++ b/src/modules/quiz/use-cases/list-quizzes/list-quizzes.query.ts
@@ -2,12 +2,18 @@ import { IQuery } from '@nestjs/cqrs';
 
 export interface IListQuizzesQueryProps {
   imageFileName?: string;
+  page?: number;
+  perPage?: number;
 }
 
 export class ListQuizzesQuery implements IQuery {
   readonly imageFileName?: string;
+  readonly page?: number;
+  readonly perPage?: number;
 
   constructor(props: IListQuizzesQueryProps) {
     this.imageFileName = props.imageFileName;
+    this.page = props.page;
+    this.perPage = props.perPage;
   }
 }


### PR DESCRIPTION
### Short description

어드민 퀴즈 리스트 조회 API에 페이지네이션 추가

### Proposed changes

- 어드민 퀴즈 리스트 조회 API에 페이지네이션 추가

### How to test (Optional)

```bash
curl -X 'GET' \
  'http://localhost:3000/admin/quizzes?&perPage=20' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI3Njk4NTIwMTAxOTAxNDU1NjIiLCJyb2xlIjoiYWRtaW4iLCJpYXQiOjE3NjI3NDkxNDMsImV4cCI6MTc5NDMwNjc0MywiaXNzIjoicXVpenplc19nYW1lX2lvX2JhY2tlbmQifQ.OpWJ4hE3MjXavwmU7ZS62mFDwb0vh3fSRMUCbVR8F28'
```

### Reference (Optional)

Closes #154 