### PR TITLE
nullable 필드의 스웨거 스키마 타입이 정확하게 표현되게 수정

### DIFF
--- a/src/common/base/base.dto.ts
+++ b/src/common/base/base.dto.ts
@@ -27,6 +27,7 @@ export class BaseResponseDto {
 
 export abstract class BaseCursorPaginationResponseDto<T> {
   @ApiProperty({
+    type: String,
     nullable: true,
   })
   cursor: string | null;

--- a/src/modules/account/dto/account.admin-dto.ts
+++ b/src/modules/account/dto/account.admin-dto.ts
@@ -31,11 +31,15 @@ export class AccountAdminDto extends BaseResponseDto {
 
   @ApiProperty({
     description: '진입 시점',
+    type: String,
     nullable: true,
   })
   enteredAt: Date | null;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({
+    type: String,
+    nullable: true,
+  })
   leftAt: Date | null;
 
   @ApiProperty()

--- a/src/modules/account/dto/account.dto.ts
+++ b/src/modules/account/dto/account.dto.ts
@@ -31,11 +31,15 @@ export class AccountDto extends BaseResponseDto {
 
   @ApiProperty({
     description: '진입 시점',
+    type: String,
     nullable: true,
   })
   enteredAt: Date | null;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({
+    type: String,
+    nullable: true,
+  })
   leftAt: Date | null;
 
   @ApiProperty()

--- a/src/modules/avatar/dto/avatar.admin-dto.ts
+++ b/src/modules/avatar/dto/avatar.admin-dto.ts
@@ -30,7 +30,10 @@ export class AvatarAdminDto extends BaseResponseDto {
   @ApiProperty()
   height: number;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({
+    type: String,
+    nullable: true,
+  })
   description: string | null;
 
   @ApiProperty()

--- a/src/modules/sound-effect/dto/sound-effect-admin.dto.ts
+++ b/src/modules/sound-effect/dto/sound-effect-admin.dto.ts
@@ -24,6 +24,9 @@ export class SoundEffectAdminDto extends BaseResponseDto {
   @ApiProperty()
   contentLength: number;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({
+    type: String,
+    nullable: true,
+  })
   description: string | null;
 }

--- a/src/modules/sound-effect/dto/sound-effect.dto.ts
+++ b/src/modules/sound-effect/dto/sound-effect.dto.ts
@@ -24,6 +24,9 @@ export class SoundEffectDto extends BaseResponseDto {
   @ApiProperty()
   contentLength: number;
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({
+    type: String,
+    nullable: true,
+  })
   description: string | null;
 }


### PR DESCRIPTION
### Short description

nullable 필드의 스웨거 스키마 타입이 정확하게 표현되게 수정

### Proposed changes

- nullable 필드의 스웨거 스키마 타입이 정확하게 표현되게 수정

### How to test (Optional)

<img width="269" height="329" alt="image" src="https://github.com/user-attachments/assets/719a70a9-c1d1-497f-b4a4-f8122ce38d99" />


### Reference (Optional)

Closes #228 
